### PR TITLE
add devices, masterdevice and recoverydevice setup

### DIFF
--- a/apps/backend/prisma/migrations/20220428133008_add_devices/migration.sql
+++ b/apps/backend/prisma/migrations/20220428133008_add_devices/migration.sql
@@ -29,7 +29,7 @@ CREATE TABLE "Device" (
     "signingPublicKey" TEXT NOT NULL,
     "encryptionPublicKey" TEXT NOT NULL,
     "encryptionPublicKeySignature" TEXT NOT NULL,
-    "username" TEXT NOT NULL,
+    "username" TEXT,
 
     CONSTRAINT "Device_pkey" PRIMARY KEY ("signingPublicKey")
 );
@@ -53,4 +53,4 @@ ALTER TABLE "RecoveryDevice" ADD CONSTRAINT "RecoveryDevice_userUsername_fkey" F
 ALTER TABLE "RecoveryDevice" ADD CONSTRAINT "RecoveryDevice_deviceSigningPublicKey_fkey" FOREIGN KEY ("deviceSigningPublicKey") REFERENCES "Device"("signingPublicKey") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Device" ADD CONSTRAINT "Device_username_fkey" FOREIGN KEY ("username") REFERENCES "User"("username") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Device" ADD CONSTRAINT "Device_username_fkey" FOREIGN KEY ("username") REFERENCES "User"("username") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -106,8 +106,9 @@ model Device {
   signingPublicKey             String          @id @unique
   encryptionPublicKey          String
   encryptionPublicKeySignature String
-  user                         User            @relation(fields: [username], references: [username])
-  username                     String
+  // can't be mandatory since we need to create the device
+  user                         User?           @relation(fields: [username], references: [username])
+  username                     String?
   recoveryDevice               RecoveryDevice?
   userForMaster                User?           @relation("masterDevice")
 }


### PR DESCRIPTION
NOTE: running the schema changes mean the local DB must be wiped

The database schema makes sure that
- the masterDevice (and all of it's fields are mandatory)
- the recoveryDevice is optional
- devices, master device and recovery device are linked via the `Device` model to the user the and publicSigningKey is unique across all devices

Next step:
- [ ] instead of saving a private/public signing key in the OPAQUE envelope safe a secret box `key` that's used to encrypt/decrypt the `masterDeviceCiphertext`
- [ ] on registration the user must send along a `masterDeviceCiphertext`, `masterDeviceNonce`, `masterDeviceSigningPublicKey`, `masterDeviceEncryptionPublicKey` and a signature of the `masterDeviceEncryptionPublicKey`
- [ ] after login the authenticated user retrieves the `masterDeviceCiphertext` & `masterDeviceNonce` and using the `key` storred in the OPAQUE envelope decrypt the `masterDeviceCiphertext` to retrieve the master device `signingPrivateKey` and `encryptionPrivateKey`