### PR TITLE
fix updating the document name

### DIFF
--- a/apps/app/components/sidebar/Sidebar.tsx
+++ b/apps/app/components/sidebar/Sidebar.tsx
@@ -98,13 +98,14 @@ export default function Sidebar(props: DrawerContentComponentProps) {
   const updateDocumentName = async (id: string) => {
     const name = window.prompt("Enter a document name");
     if (name && name.length > 0) {
-      const updatedDocument = await updateDocumentNameMutation({
+      // refetchDocumentPreviews no necessary since a document is returned
+      // and therefor the cache automatically updated
+      await updateDocumentNameMutation({
         input: {
           id,
           name,
         },
       });
-      refetchDocumentPreviews();
     }
   };
 

--- a/apps/backend/src/database/document/deleteDocuments.ts
+++ b/apps/backend/src/database/document/deleteDocuments.ts
@@ -23,7 +23,6 @@ export async function deleteDocuments({ documentIds, username }: Params) {
       const workspaceIds = userToWorkspaces.map(
         (userToWorkspace) => userToWorkspace.workspaceId
       );
-      console.log("DELETE MANY workspaceIds", workspaceIds, documentIds);
       await prisma.document.deleteMany({
         where: {
           id: {

--- a/apps/backend/src/database/document/updateDocumentName.ts
+++ b/apps/backend/src/database/document/updateDocumentName.ts
@@ -8,7 +8,7 @@ type Params = {
 
 export async function updateDocumentName({ id, name, username }: Params) {
   try {
-    await prisma.$transaction(async (prisma) => {
+    return await prisma.$transaction(async (prisma) => {
       // fetch the document
       // check if the user has access to the document
       // update the document
@@ -35,12 +35,8 @@ export async function updateDocumentName({ id, name, username }: Params) {
         throw Error("Unauthorized");
       }
       const updatedDocument = await prisma.document.update({
-        where: {
-          id,
-        },
-        data: {
-          name,
-        },
+        where: { id },
+        data: { name },
       });
       return updatedDocument;
     });

--- a/apps/backend/src/graphql/mutations/document/updateDocumentName.test.ts
+++ b/apps/backend/src/graphql/mutations/document/updateDocumentName.test.ts
@@ -55,7 +55,10 @@ test("user should be able to change a document name", async () => {
   });
   expect(result.updateDocumentName).toMatchInlineSnapshot(`
     Object {
-      "document": null,
+      "document": Object {
+        "id": "5a3484e6-c46e-42ce-a285-088fc1fd6915",
+        "name": "Updated Name",
+      },
     }
   `);
 });


### PR DESCRIPTION
When updating the document name it was not reflected as it should have been in the UI due the urql cache