### PR TITLE
remove outline on Editor focus when writing

### DIFF
--- a/packages/editor/editor-input.css
+++ b/packages/editor/editor-input.css
@@ -206,7 +206,11 @@
 
 /* --- ProseMirror --- */
 
+/* needed overrides to disable focus-outline while writing inside the Editor */
 .ProseMirror:focus {
+  outline: none;
+}
+.ProseMirror[data-focusvisible-polyfill] {
   outline: none;
 }
 
@@ -218,6 +222,9 @@
 
 .show-sections .ProseMirror {
   background-color: rgba(255, 230, 147, 0.5);
+}
+.show-sections .ProseMirror[data-focusvisible-polyfill] {
+  outline: 2px solid orange;
 }
 .show-sections h1,
 .show-sections h2,


### PR DESCRIPTION
Override focus-outline which occurs while writing in Editor, as the cursor is indication enough to show the focus is set.