### PR TITLE
add some bottom spacing for the scrollable sidebar

### DIFF
--- a/apps/app/components/sidebar/Sidebar.tsx
+++ b/apps/app/components/sidebar/Sidebar.tsx
@@ -103,7 +103,7 @@ export default function Sidebar(props: DrawerContentComponentProps) {
 
   return (
     // TODO override for now until we find out where the pt-1 comes from
-    <DrawerContentScrollView {...props} style={tw`bg-gray-100 -mt-1`}>
+    <DrawerContentScrollView {...props} style={tw`bg-gray-100 -mt-1 pb-4`}>
       <HStack
         alignItems="center"
         justifyContent="space-between"


### PR DESCRIPTION
After the change:
<img width="273" alt="Screenshot 2022-06-23 at 14 23 24" src="https://user-images.githubusercontent.com/223045/175297945-60ed4916-d367-4286-a1a9-38eca49bbc99.png">

Before the change:
<img width="252" alt="Screenshot 2022-06-23 at 14 25 04" src="https://user-images.githubusercontent.com/223045/175298044-a96a6769-5db0-46e2-913e-3dab1705e7c3.png">

