### PR TITLE
Enforce light mode

### DIFF
--- a/apps/app/App.tsx
+++ b/apps/app/App.tsx
@@ -132,8 +132,10 @@ export default function App() {
     Inter_600SemiBold,
     Inter_700Bold,
   });
-  useDeviceContext(tw);
-  const [colorScheme] = useAppColorScheme(tw);
+  // 1️opt out of listening to device color scheme events until we support dark mode
+  useDeviceContext(tw, { withDeviceColorScheme: false });
+  // hard-coding the colorScheme to light until we support dark mode
+  const [colorScheme] = useAppColorScheme(tw, "light");
   const rnTheme = extendTheme({
     colors: {
       ...theme.colors,


### PR DESCRIPTION
The interface doesn't look good on dark mode at the moment. To not annoy dark mode users we want to enforce light mode until we support dark mode.