### PR TITLE
Style breadcrumbs and use Icon as separator

### DIFF
--- a/apps/app/components/page/PageHeader.tsx
+++ b/apps/app/components/page/PageHeader.tsx
@@ -1,5 +1,5 @@
 import { DrawerHeaderProps } from "@react-navigation/drawer";
-import { Text, View } from "@serenity-tools/ui";
+import { Icon, Text, tw } from "@serenity-tools/ui";
 import { HStack } from "native-base";
 import { useDocumentPathStore } from "../../utils/document/documentPathStore";
 import { useDocumentStore } from "../../utils/document/documentStore";
@@ -13,15 +13,20 @@ export function PageHeader(props: Props) {
   const document = useDocumentStore((state) => state.document);
 
   return (
-    <HStack space={2} alignItems="center">
+    <HStack space={0.5} alignItems="center">
       {documentPathList.map((folder) => (
-        <Text>
-          <Text key={folder.id}>{folder.name}</Text>
-          {/* TOOD: use a right chevron icon */}
-          <Text> &gt;</Text>
-        </Text>
+        <HStack alignItems="center" space={0.5}>
+          <Text key={folder.id} variant="xxs" muted>
+            {folder.name}
+          </Text>
+          <Icon name="arrow-right-s-line" color={tw.color("gray-600")} />
+        </HStack>
       ))}
-      {document && <Text bold>{document.name}</Text>}
+      {document && (
+        <Text variant="xxs" bold>
+          {document.name}
+        </Text>
+      )}
     </HStack>
   );
 }


### PR DESCRIPTION
Add `Icon` as separator for breadcrumbs and adjust styling to fit Design.