### PR TITLE
improve api errors

### DIFF
--- a/apps/backend/src/database/workspace/getWorkspaceInvitations.ts
+++ b/apps/backend/src/database/workspace/getWorkspaceInvitations.ts
@@ -1,5 +1,6 @@
 import { prisma } from "../prisma";
 import { WorkspaceInvitation } from "../../types/workspace";
+import { ForbiddenError } from "apollo-server-express";
 
 type Cursor = {
   id?: string;
@@ -27,7 +28,7 @@ export async function getWorkspaceInvitations({
     },
   });
   if (!userToWorkspaces) {
-    throw new Error("Unauthorized");
+    throw new ForbiddenError("Unauthorized");
   }
   const rawWorkspaceInvitations = await prisma.workspaceInvitations.findMany({
     where: {

--- a/apps/backend/src/graphql/queries/workspace/workspaceInvitations.ts
+++ b/apps/backend/src/graphql/queries/workspace/workspaceInvitations.ts
@@ -1,3 +1,4 @@
+import { AuthenticationError, UserInputError } from "apollo-server-express";
 import { idArg, nonNull, queryField } from "nexus";
 import { getWorkspaceInvitations } from "../../../database/workspace/getWorkspaceInvitations";
 import { WorkspaceInvitation } from "../../types/workspace";
@@ -13,12 +14,13 @@ export const workspaceInvitations = queryField((t) => {
     },
     async nodes(root, args, context) {
       if (args.first > 50) {
-        throw new Error(
-          "Requested too many workspace invitations. First value exceeds 50."
+        throw new UserInputError(
+          "Requested too many workspace invitations. First value exceeds 50.",
+          { invalidArgs: ["first"] }
         );
       }
       if (!context.user) {
-        throw new Error("Unauthorized");
+        throw new AuthenticationError("Not authenticated");
       }
       const userId = context.user.id;
       const cursor = args.after ? { id: args.after } : undefined;

--- a/apps/backend/test/helpers/workspace/workspaceInvitations.ts
+++ b/apps/backend/test/helpers/workspace/workspaceInvitations.ts
@@ -4,19 +4,21 @@ type Params = {
   graphql: any;
   workspaceId: string;
   authorizationHeader: string;
+  first?: number;
 };
 
 export const workspaceInvitations = async ({
   graphql,
   workspaceId,
   authorizationHeader,
+  first = 50,
 }: Params) => {
   const authorizationHeaders = {
     authorization: authorizationHeader,
   };
   const query = gql`
     {
-        workspaceInvitations(workspaceId: "${workspaceId}", first: 50) {
+        workspaceInvitations(workspaceId: "${workspaceId}", first: ${first}) {
             edges {
                 node {
                     id


### PR DESCRIPTION
There are pre-defined errors that come with Apollo server: https://www.apollographql.com/docs/apollo-server/data/errors/#error-codes

It makes sense to start using them especially to differentiate between `unauthenticated vs forbidden` to later handle cases where session keys expire and we need to redirect the user