### PR TITLE
start mobile navigation from register screen & refactoring

### DIFF
--- a/apps/app/app.config.js
+++ b/apps/app/app.config.js
@@ -26,7 +26,7 @@ export default {
     android: {
       package: "re.serenity.app",
       adaptiveIcon: {
-        foregroundImage: "./assets/logo_serenity_android.png",
+        foregroundImage: "./assets/images/logo_serenity_android.png",
         backgroundColor: "#FFF",
       },
       // permissions: [],

--- a/apps/app/navigation/Navigation.tsx
+++ b/apps/app/navigation/Navigation.tsx
@@ -80,11 +80,6 @@ function WorkspaceStackScreen(props) {
           overlayColor: "transparent",
         }}
       >
-        <Drawer.Screen
-          name="NoPageExists"
-          component={NoPageExistsScreen}
-          options={{ headerShown: false }}
-        />
         <Drawer.Screen name="Page" component={PageScreen} />
         <Drawer.Screen name="Settings" component={WorkspaceSettingsScreen} />
         <Drawer.Screen
@@ -93,6 +88,11 @@ function WorkspaceStackScreen(props) {
           options={{ headerShown: false }}
         />
         <Drawer.Screen name="DeviceManager" component={DeviceManagerScreen} />
+        <Drawer.Screen
+          name="NoPageExists"
+          component={NoPageExistsScreen}
+          options={{ headerShown: false }}
+        />
       </Drawer.Navigator>
     </WorkspaceIdProvider>
   );
@@ -101,7 +101,6 @@ function WorkspaceStackScreen(props) {
 function RootNavigator() {
   return (
     <Stack.Navigator>
-      <Stack.Screen name="DevDashboard" component={DevDashboardScreen} />
       <Stack.Screen
         name="Root"
         component={RootScreen}
@@ -138,11 +137,7 @@ function RootNavigator() {
         component={EncryptDecryptImageTestScreen}
       />
       <Stack.Screen name="TestLibsodium" component={LibsodiumTestScreen} />
-      <Stack.Screen
-        name="NotFound"
-        component={NotFoundScreen}
-        options={{ headerShown: false }}
-      />
+      <Stack.Screen name="DevDashboard" component={DevDashboardScreen} />
       <Stack.Screen
         name="AcceptWorkspaceInvitation"
         component={AcceptWorkspaceInvitationScreen}
@@ -151,6 +146,11 @@ function RootNavigator() {
       <Stack.Screen
         name="WorkspaceNotFound"
         component={WorkspaceNotFoundScreen}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="NotFound"
+        component={NotFoundScreen}
         options={{ headerShown: false }}
       />
     </Stack.Navigator>

--- a/apps/app/navigation/screens/DevDashboardScreen.tsx
+++ b/apps/app/navigation/screens/DevDashboardScreen.tsx
@@ -1,4 +1,10 @@
-import { Link, Text, tw, ScrollSafeAreaView } from "@serenity-tools/ui";
+import {
+  SidebarLink,
+  tw,
+  ScrollSafeAreaView,
+  Icon,
+  Text,
+} from "@serenity-tools/ui";
 import { useWindowDimensions } from "react-native";
 
 export default function DevDashboardScreen(props) {
@@ -6,13 +12,42 @@ export default function DevDashboardScreen(props) {
 
   return (
     <ScrollSafeAreaView style={tw`px-4 py-6`}>
-      <Text>Dev Dashboard Screen</Text>
-      <Link to={{ screen: "DesignSystem" }}>Design System</Link>
-      <Link to={{ screen: "Root" }}>Root</Link>
-      <Link to={{ screen: "TestLibsodium" }}>Libsodium Test Screen</Link>
-      <Link to={{ screen: "EncryptDecryptImageTest" }}>
-        Encrypt / Decrypt Image
-      </Link>
+      <SidebarLink to={{ screen: "Root" }}>
+        <Icon
+          name="dashboard-line"
+          size={4.5}
+          mobileSize={5.5}
+          color={tw.color("gray-800")}
+        />
+        <Text>Home</Text>
+      </SidebarLink>
+      <SidebarLink to={{ screen: "DesignSystem" }}>
+        <Icon
+          name="dashboard-line"
+          size={4.5}
+          mobileSize={5.5}
+          color={tw.color("gray-800")}
+        />
+        <Text>Design System</Text>
+      </SidebarLink>
+      <SidebarLink to={{ screen: "TestLibsodium" }}>
+        <Icon
+          name="dashboard-line"
+          size={4.5}
+          mobileSize={5.5}
+          color={tw.color("gray-800")}
+        />
+        <Text>Libsodium Test Screen</Text>
+      </SidebarLink>
+      <SidebarLink to={{ screen: "EncryptDecryptImageTest" }}>
+        <Icon
+          name="dashboard-line"
+          size={4.5}
+          mobileSize={5.5}
+          color={tw.color("gray-800")}
+        />
+        <Text>Encrypt / Decrypt Image</Text>
+      </SidebarLink>
     </ScrollSafeAreaView>
   );
 }

--- a/apps/app/navigation/screens/RegisterScreen.tsx
+++ b/apps/app/navigation/screens/RegisterScreen.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Text, View, Box, tw, Link } from "@serenity-tools/ui";
+import { Text, View, Box, tw, Link, Icon } from "@serenity-tools/ui";
 import { RootStackScreenProps } from "../../types/navigation";
 import RegisterForm from "../../components/register/RegisterForm";
 import { KeyboardAvoidingView } from "react-native";
@@ -40,6 +40,11 @@ export default function RegisterScreen(
               <Link to={{ screen: "Login" }}>Login here</Link>
             </View>
           </Box>
+          <View style={tw`absolute left-0 ios:left-4 bottom-0`}>
+            <Link to={{ screen: "DevDashboard" }} style={tw`p-4`}>
+              <Icon name="dashboard-line" color={tw.color("gray-500")} />
+            </Link>
+          </View>
         </View>
       </KeyboardAvoidingView>
     </SafeAreaView>


### PR DESCRIPTION
- Start mobile navigation from register screen by moving it to the top of the screen list in the code
- Refactored the "Not Exists" pages to the end
- Add link to dev dashboard from register screen on the bottom left (see screenshots)

<img width="372" alt="Screenshot 2022-07-17 at 18 40 04" src="https://user-images.githubusercontent.com/223045/179414650-d502c22a-1fdb-495b-98ca-5023c570a796.png">

<img width="734" alt="Screenshot 2022-07-17 at 18 39 57" src="https://user-images.githubusercontent.com/223045/179414610-078b1c67-8a2f-4c6c-a141-0ea7deb2bf17.png">

