### PR TITLE
fix expo-crypto package

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -45,7 +45,7 @@
     "expo-asset": "~8.4.4",
     "expo-clipboard": "~2.1.0",
     "expo-constants": "~13.0.0",
-    "expo-crypto": "^10.2.0",
+    "expo-crypto": "~10.1.1",
     "expo-dev-client": "~0.8.5",
     "expo-font": "~10.0.4",
     "expo-image-picker": "^12.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9958,10 +9958,10 @@ expo-constants@~13.0.0, expo-constants@~13.0.2:
     "@expo/config" "^6.0.6"
     uuid "^3.3.2"
 
-expo-crypto@^10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/expo-crypto/-/expo-crypto-10.2.0.tgz#86d16e7e93b62af37d9ded3d344744e94d6ab4e4"
-  integrity sha512-YVFp+DJXBtt4t6oZXepnzb+xwpKzFbXn3B9Oma1Tfh6J0rIlm/I20UW/5apdvEdbj44fxJ5DsiZeyADI3bcZkQ==
+expo-crypto@~10.1.1:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/expo-crypto/-/expo-crypto-10.1.2.tgz#5dfc0f0a5b4aa94dae2ecfb744d4aa8c001660b7"
+  integrity sha512-TYaBtV9oK5OH+EfsAUHQkWkRPifZjCMDn6Yf9gk3/LyHdJHDYnB6NQWTJo9Qkl6vzI9svQ6PMnQTm2Yxrb3ZfQ==
 
 expo-dev-client@~0.8.5:
   version "0.8.5"


### PR DESCRIPTION
Expo modules must be installed with `yarn expo install expo-crypto`. Otherwise the wrong version might be installed and app builds will fail.