### PR TITLE
Fix word-wrap issues on checkbox-text

### DIFF
--- a/packages/editor/editor-input.css
+++ b/packages/editor/editor-input.css
@@ -140,6 +140,7 @@
   .task-item-extension label + div {
     padding-left: 0.5rem;
     flex-grow: 1;
+    overflow-wrap: anywhere; /* needed so longer words break midline and not the ui */
   }
   .task-item-extension input[type="checkbox"] {
     opacity: 0;


### PR DESCRIPTION
Add wrap setting to get checkbox-text to wrap on overflowing words.