### PR TITLE
cleanup console output

### DIFF
--- a/apps/app/App.tsx
+++ b/apps/app/App.tsx
@@ -20,8 +20,11 @@ import { ErrorBoundary } from "./components/errorBoundary/ErrorBoundary";
 import { AppContextProvider } from "./context/AppContext";
 import useCachedResources from "./hooks/useCachedResources";
 import Navigation from "./navigation/Navigation";
+import { patchConsoleOutput } from "./utils/patchConsoleOutput/patchConsoleOutput";
 import { recreateClient } from "./utils/urqlClient/urqlClient";
 import { source } from "./webviews/opaque/source";
+
+patchConsoleOutput();
 
 // import { clearDeviceAndSessionStorage } from "./utils/authentication/clearDeviceAndSessionStorage";
 // clearDeviceAndSessionStorage();

--- a/apps/app/utils/patchConsoleOutput/patchConsoleOutput.ts
+++ b/apps/app/utils/patchConsoleOutput/patchConsoleOutput.ts
@@ -1,0 +1,25 @@
+export const patchConsoleOutput = () => {
+  const originalConsoleError = console.error;
+  console.error = (...args) => {
+    if (
+      (args[0] &&
+        args[0].includes(
+          "Warning: React has detected a change in the order of Hooks called by %s"
+        ) &&
+        args[1] &&
+        args[1] === "Header") ||
+      (args[0] &&
+        args[0].includes(
+          'Warning: Each child in a list should have a unique "key" prop.'
+        ) &&
+        args[1] &&
+        args[1].includes(
+          "Check the render method of `ForwardRef(AvatarGroup)`"
+        ))
+    ) {
+      // ignored
+    } else {
+      originalConsoleError(...args);
+    }
+  };
+};

--- a/apps/app/utils/urqlClient/urqlClient.ts
+++ b/apps/app/utils/urqlClient/urqlClient.ts
@@ -21,6 +21,8 @@ const exchanges = [
   cacheExchange({
     keys: {
       WorkspaceMember: () => null, // since it has no unique key
+      CreatorDevice: () => null, // since it has no unique key
+      UnauthorizedMembersResult: () => null, // since it has no unique key
       // @ts-expect-error the type seems to be wrong
       MainDeviceResult: (mainDevice) => {
         return mainDevice.signingPublicKey;


### PR DESCRIPTION
- patch console to avoid long errors coming from dependencies
- properly configuring the urql cache for recently added queries and fields

Before:
<img width="422" alt="Screenshot 2022-09-27 at 16 34 54" src="https://user-images.githubusercontent.com/223045/192560631-3cbfe65f-531c-48a5-802f-c19dd99267e9.png">

After:
<img width="423" alt="Screenshot 2022-09-27 at 16 34 30" src="https://user-images.githubusercontent.com/223045/192560677-423a724e-d0de-4f92-8a84-ddce1e538ea4.png">
