### PR TITLE
Extract account menu

### DIFF
--- a/apps/app/components/accountMenu/AccountMenu.tsx
+++ b/apps/app/components/accountMenu/AccountMenu.tsx
@@ -1,0 +1,184 @@
+import { useFocusRing } from "@react-native-aria/focus";
+import { useNavigation } from "@react-navigation/native";
+import {
+  Icon,
+  IconButton,
+  Menu,
+  MenuButton,
+  MenuLink,
+  Pressable,
+  SidebarDivider,
+  Text,
+  tw,
+  useIsDesktopDevice,
+  useIsPermanentLeftSidebar,
+  View,
+  WorkspaceAvatar,
+} from "@serenity-tools/ui";
+import { HStack } from "native-base";
+import { useState } from "react";
+import { Platform } from "react-native";
+import { Workspace } from "../../generated/graphql";
+import { useWorkspaceContext } from "../../hooks/useWorkspaceContext";
+import { clearDeviceAndSessionStorage } from "../../utils/authentication/clearDeviceAndSessionStorage";
+
+type Props = {
+  workspace: Workspace | null;
+  workspaces: Workspace[] | null | undefined;
+  username: string;
+  showCreateWorkspaceModal: () => void;
+};
+
+export default function AccountMenu({
+  workspace,
+  workspaces,
+  username,
+  showCreateWorkspaceModal,
+}: Props) {
+  const [isOpenWorkspaceSwitcher, setIsOpenWorkspaceSwitcher] = useState(false);
+  const { updateAuthentication } = useWorkspaceContext();
+  const { isFocusVisible, focusProps: focusRingProps } = useFocusRing();
+  const isDesktopDevice = useIsDesktopDevice();
+  const isPermanentLeftSidebar = useIsPermanentLeftSidebar();
+  const navigation = useNavigation();
+
+  return (
+    <Menu
+      placement="bottom left"
+      // we could solve this via additional margin but that's kinda hacky and messes with the BoxShadow component
+      // style={tw`ml-4`}
+      offset={2}
+      // can never be more than half the trigger width !! should be something like 16+24+8+labellength*12-24
+      // or we only use the icon as the trigger (worsens ux)
+      crossOffset={120}
+      isOpen={isOpenWorkspaceSwitcher}
+      onChange={setIsOpenWorkspaceSwitcher}
+      trigger={
+        <Pressable
+          accessibilityLabel="More options menu"
+          {...focusRingProps}
+          // disable default outline styles
+          // @ts-expect-error - web only
+          _focusVisible={{ _web: { style: { outlineStyle: "none" } } }}
+        >
+          <HStack
+            space={isPermanentLeftSidebar ? 2 : 3}
+            alignItems="center"
+            style={[
+              tw`py-0.5 md:py-1.5 pr-2`,
+              isFocusVisible && tw`se-inset-focus-mini`,
+            ]}
+          >
+            <WorkspaceAvatar size={isPermanentLeftSidebar ? "xs" : "sm"} />
+            <Text
+              variant={isPermanentLeftSidebar ? "xs" : "md"}
+              bold
+              style={tw`-mr-1 max-w-30 text-gray-900`} // -mr needed for icon spacing, max-w needed for ellipsis
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            >
+              {workspace === null ? " " : workspace.name}
+            </Text>
+            <Icon name="arrow-up-down-s-line" color={"gray-400"} />
+          </HStack>
+        </Pressable>
+      }
+    >
+      <MenuLink
+        to={{ screen: "AccountSettings" }}
+        onPress={(event) => {
+          setIsOpenWorkspaceSwitcher(false);
+          // on iOS Modals can't be open at the same time
+          // and closing the workspace switcher takes a bit of time
+          // technically we only need it for tables and larger, but
+          // don't want to complicate things for now
+          if (Platform.OS === "ios") {
+            event.preventDefault();
+            setTimeout(() => {
+              navigation.navigate("AccountSettings", {
+                screen: "Profile",
+              });
+            }, 400);
+          }
+        }}
+        icon={<Icon name={"user-settings-line"} color="gray-600" />}
+      >
+        {username}
+      </MenuLink>
+
+      {workspaces === null ||
+      workspaces === undefined ||
+      workspaces.length === 0
+        ? null
+        : workspaces.map((workspace) =>
+            workspace === null || workspace === undefined ? null : (
+              <MenuLink
+                key={workspace.id}
+                to={{
+                  screen: "Workspace",
+                  params: {
+                    workspaceId: workspace.id,
+                    screen: "WorkspaceRoot",
+                  },
+                }}
+                icon={
+                  <WorkspaceAvatar
+                    customColor={"honey"}
+                    key={`avatar_${workspace.id}`}
+                    size="xxs"
+                  />
+                }
+              >
+                {workspace.name}
+              </MenuLink>
+            )
+          )}
+
+      {isDesktopDevice ? (
+        <View style={tw`pl-1.5 pr-3 py-1.5`}>
+          <IconButton
+            onPress={() => {
+              setIsOpenWorkspaceSwitcher(false);
+              // on mobile Modals can't be open at the same time
+              // and closing the workspace switcher takes a bit of time
+              const timeout = Platform.OS === "web" ? 0 : 400;
+              setTimeout(() => {
+                showCreateWorkspaceModal();
+              }, timeout);
+            }}
+            name="plus"
+            label="Create workspace"
+          />
+        </View>
+      ) : (
+        <MenuButton
+          onPress={() => {
+            setIsOpenWorkspaceSwitcher(false);
+            // on mobile Modals can't be open at the same time
+            // and closing the workspace switcher takes a bit of time
+            const timeout = Platform.OS === "web" ? 0 : 400;
+            setTimeout(() => {
+              showCreateWorkspaceModal();
+            }, timeout);
+          }}
+          iconName="plus"
+        >
+          Create workspace
+        </MenuButton>
+      )}
+
+      <SidebarDivider collapsed />
+      <MenuButton
+        onPress={async () => {
+          setIsOpenWorkspaceSwitcher(false);
+          await updateAuthentication(null);
+          clearDeviceAndSessionStorage();
+          // @ts-expect-error navigation ts issue
+          props.navigation.push("Login");
+        }}
+      >
+        Logout
+      </MenuButton>
+    </Menu>
+  );
+}

--- a/apps/app/components/sidebarFolder/SidebarFolder.tsx
+++ b/apps/app/components/sidebarFolder/SidebarFolder.tsx
@@ -142,11 +142,12 @@ export default function SidebarFolder(props: Props) {
       workspaceId: props.workspaceId,
     });
     try {
-      workspaceKey = await getWorkspaceKey({
+      const result = await getWorkspaceKey({
         workspaceId: props.workspaceId,
         urqlClient,
         activeDevice,
       });
+      workspaceKey = result.workspaceKey;
     } catch (error: any) {
       // TODO: handle device not registered error
       console.error(error);

--- a/apps/app/navigation/screens/accountDevicesSettingsScreen/AccountDevicesSettingsScreen.tsx
+++ b/apps/app/navigation/screens/accountDevicesSettingsScreen/AccountDevicesSettingsScreen.tsx
@@ -80,7 +80,7 @@ export default function DeviceManagerScreen(props) {
             receiverDeviceEncryptionPublicKey: device.encryptionPublicKey,
             creatorDeviceEncryptionPrivateKey:
               activeDevice.encryptionPrivateKey!,
-            workspaceKey,
+            workspaceKey: workspaceKey.workspaceKey,
           });
         workspaceDevicePairing.push({
           ciphertext,

--- a/apps/app/navigation/screens/workspaceSettingsMembersScreen/WorkspaceSettingsMembersScreen.tsx
+++ b/apps/app/navigation/screens/workspaceSettingsMembersScreen/WorkspaceSettingsMembersScreen.tsx
@@ -232,7 +232,7 @@ export default function WorkspaceSettingsMembersScreen(
               receiverDeviceEncryptionPublicKey: device.encryptionPublicKey,
               creatorDeviceEncryptionPrivateKey:
                 activeDevice.encryptionPrivateKey!,
-              workspaceKey,
+              workspaceKey: workspaceKey.workspaceKey,
             });
           deviceWorkspaceKeyBoxes.push({
             ciphertext,

--- a/apps/app/utils/folder/getParentFolderKey.ts
+++ b/apps/app/utils/folder/getParentFolderKey.ts
@@ -35,7 +35,7 @@ export const getParentFolderKey = async ({
       urqlClient,
       activeDevice,
     });
-    parentKey = workspaceKey;
+    parentKey = workspaceKey.workspaceKey;
   }
   return parentKey;
 };

--- a/apps/app/utils/workspace/getWorkspaceKey.ts
+++ b/apps/app/utils/workspace/getWorkspaceKey.ts
@@ -18,6 +18,11 @@ export const getWorkspaceKey = async ({
     deviceSigningPublicKey: activeDevice.signingPublicKey,
     workspaceId: workspaceId,
   });
+  if (!workspace?.currentWorkspaceKey?.id) {
+    throw new Error(
+      "The currentWorkspaceKey has no ID. This should never happen."
+    );
+  }
   const workspaceKeyBox = workspace?.currentWorkspaceKey?.workspaceKeyBox;
   if (!workspaceKeyBox) {
     throw new Error("This device isn't registered for this workspace!");
@@ -35,5 +40,8 @@ export const getWorkspaceKey = async ({
     creatorDeviceEncryptionPublicKey: creatorDevice.encryptionPublicKey,
     receiverDeviceEncryptionPrivateKey: activeDevice.encryptionPrivateKey!,
   });
-  return workspaceKey;
+  return {
+    id: workspace?.currentWorkspaceKey?.id,
+    workspaceKey,
+  };
 };


### PR DESCRIPTION
Background: This a a first step to make the Account menu also available on screens when no current workspace is active.

We extract the AccountMenu into a separate component and instead of using useEffect we leverage plain useQuery.

Side effect from the refactoring: instead of using an old workspaceKeyId we not pass through the one we currently fetch. This might solve some key rotation bugs in case the user is online during key rotation. 