### PR TITLE
Add account menu to other pages

### DIFF
--- a/apps/app/components/accountMenu/AccountMenu.tsx
+++ b/apps/app/components/accountMenu/AccountMenu.tsx
@@ -27,7 +27,7 @@ import { useWorkspaceContext } from "../../hooks/useWorkspaceContext";
 import { clearDeviceAndSessionStorage } from "../../utils/authentication/clearDeviceAndSessionStorage";
 
 type Props = {
-  workspaceId: string;
+  workspaceId?: string;
   showCreateWorkspaceModal: () => void;
 };
 
@@ -48,6 +48,7 @@ export default function AccountMenu({
       id: workspaceId,
       deviceSigningPublicKey: activeDevice.signingPublicKey,
     },
+    pause: !workspaceId,
   });
   const [workspacesResult] = useWorkspacesQuery({
     variables: { deviceSigningPublicKey: activeDevice.signingPublicKey },
@@ -88,7 +89,9 @@ export default function AccountMenu({
               numberOfLines={1}
               ellipsizeMode="tail"
             >
-              {workspaceResult.data?.workspace?.name || " "}
+              {workspaceId
+                ? workspaceResult.data?.workspace?.name || " "
+                : "No workspace"}
             </Text>
             <Icon name="arrow-up-down-s-line" color={"gray-400"} />
           </HStack>
@@ -184,7 +187,7 @@ export default function AccountMenu({
           clearDeviceAndSessionStorage();
           await updateAuthentication(null);
           // @ts-expect-error navigation ts issue
-          props.navigation.push("Login");
+          navigation.push("Login");
         }}
       >
         Logout

--- a/apps/app/components/accountMenu/AccountMenu.tsx
+++ b/apps/app/components/accountMenu/AccountMenu.tsx
@@ -28,14 +28,14 @@ import { clearDeviceAndSessionStorage } from "../../utils/authentication/clearDe
 
 type Props = {
   workspaceId?: string;
-  showCreateWorkspaceModal: () => void;
+  openCreateWorkspace: () => void;
 };
 
 export default function AccountMenu({
   workspaceId,
-  showCreateWorkspaceModal,
+  openCreateWorkspace,
 }: Props) {
-  const [isOpenWorkspaceSwitcher, setIsOpenWorkspaceSwitcher] = useState(false);
+  const [isOpenAccountMenu, setIsOpenAccountMenu] = useState(false);
   const { updateAuthentication } = useWorkspaceContext();
   const { isFocusVisible, focusProps: focusRingProps } = useFocusRing();
   const isDesktopDevice = useIsDesktopDevice();
@@ -63,8 +63,8 @@ export default function AccountMenu({
       // can never be more than half the trigger width !! should be something like 16+24+8+labellength*12-24
       // or we only use the icon as the trigger (worsens ux)
       crossOffset={120}
-      isOpen={isOpenWorkspaceSwitcher}
-      onChange={setIsOpenWorkspaceSwitcher}
+      isOpen={isOpenAccountMenu}
+      onChange={setIsOpenAccountMenu}
       trigger={
         <Pressable
           accessibilityLabel="More options menu"
@@ -101,7 +101,7 @@ export default function AccountMenu({
       <MenuLink
         to={{ screen: "AccountSettings" }}
         onPress={(event) => {
-          setIsOpenWorkspaceSwitcher(false);
+          setIsOpenAccountMenu(false);
           // on iOS Modals can't be open at the same time
           // and closing the workspace switcher takes a bit of time
           // technically we only need it for tables and larger, but
@@ -151,12 +151,12 @@ export default function AccountMenu({
         <View style={tw`pl-1.5 pr-3 py-1.5`}>
           <IconButton
             onPress={() => {
-              setIsOpenWorkspaceSwitcher(false);
+              setIsOpenAccountMenu(false);
               // on mobile Modals can't be open at the same time
               // and closing the workspace switcher takes a bit of time
               const timeout = Platform.OS === "web" ? 0 : 400;
               setTimeout(() => {
-                showCreateWorkspaceModal();
+                openCreateWorkspace();
               }, timeout);
             }}
             name="plus"
@@ -166,12 +166,12 @@ export default function AccountMenu({
       ) : (
         <MenuButton
           onPress={() => {
-            setIsOpenWorkspaceSwitcher(false);
+            setIsOpenAccountMenu(false);
             // on mobile Modals can't be open at the same time
             // and closing the workspace switcher takes a bit of time
             const timeout = Platform.OS === "web" ? 0 : 400;
             setTimeout(() => {
-              showCreateWorkspaceModal();
+              openCreateWorkspace();
             }, timeout);
           }}
           iconName="plus"
@@ -183,7 +183,7 @@ export default function AccountMenu({
       <SidebarDivider collapsed />
       <MenuButton
         onPress={async () => {
-          setIsOpenWorkspaceSwitcher(false);
+          setIsOpenAccountMenu(false);
           clearDeviceAndSessionStorage();
           await updateAuthentication(null);
           // @ts-expect-error navigation ts issue

--- a/apps/app/components/sidebar/Sidebar.tsx
+++ b/apps/app/components/sidebar/Sidebar.tsx
@@ -152,7 +152,7 @@ export default function Sidebar(props: DrawerContentComponentProps) {
       >
         <AccountMenu
           workspaceId={workspaceId}
-          showCreateWorkspaceModal={() => setShowCreateWorkspaceModal(true)}
+          openCreateWorkspace={() => setShowCreateWorkspaceModal(true)}
         />
         {!isPermanentLeftSidebar && (
           <IconButton

--- a/apps/app/machines/loadInitialData.ts
+++ b/apps/app/machines/loadInitialData.ts
@@ -144,10 +144,8 @@ export const loadInitialDataMachine =
           if (context.returnOtherWorkspaceIfNotFound === true) {
             context.navigation.replace("Onboarding");
           } else {
-            context.navigation.replace("WorkspaceNotFoundScreen", {
-              workspaceId:
-                context.meWithWorkspaceLoadingInfoQueryResult?.data?.me
-                  ?.workspaceLoadingInfo?.id,
+            context.navigation.replace("WorkspaceNotFound", {
+              workspaceId: context.workspaceId,
             });
           }
         },

--- a/apps/app/navigation/screens/onboardingScreen/OnboardingScreen.tsx
+++ b/apps/app/navigation/screens/onboardingScreen/OnboardingScreen.tsx
@@ -1,12 +1,13 @@
 import { CenterContent, tw, View } from "@serenity-tools/ui";
 import { KeyboardAvoidingView, useWindowDimensions } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import AccountMenu from "../../../components/accountMenu/AccountMenu";
 import { CreateWorkspaceForm } from "../../../components/createWorkspaceForm/CreateWorkspaceForm";
 
 export default function OnboardingScreen({ navigation }) {
   useWindowDimensions(); // needed to ensure tw-breakpoints are triggered when resizing
 
-  const onWorkspaceStructureCreated = ({ workspace, folder, document }) => {
+  const onWorkspaceStructureCreated = ({ workspace, document }) => {
     navigation.navigate("Workspace", {
       workspaceId: workspace.id,
       screen: "Page",
@@ -18,6 +19,9 @@ export default function OnboardingScreen({ navigation }) {
 
   return (
     <SafeAreaView style={tw`flex-auto`}>
+      <View style={tw`py-1.5 px-5 md:px-4`}>
+        <AccountMenu showCreateWorkspaceModal={() => undefined} />
+      </View>
       <KeyboardAvoidingView behavior="padding" style={tw`flex-auto`}>
         <CenterContent>
           <View style={tw`max-w-sm p-6`}>

--- a/apps/app/navigation/screens/onboardingScreen/OnboardingScreen.tsx
+++ b/apps/app/navigation/screens/onboardingScreen/OnboardingScreen.tsx
@@ -20,7 +20,11 @@ export default function OnboardingScreen({ navigation }) {
   return (
     <SafeAreaView style={tw`flex-auto`}>
       <View style={tw`py-1.5 px-5 md:px-4`}>
-        <AccountMenu showCreateWorkspaceModal={() => undefined} />
+        <AccountMenu
+          openCreateWorkspace={() => {
+            navigation.push("Onboarding");
+          }}
+        />
       </View>
       <KeyboardAvoidingView behavior="padding" style={tw`flex-auto`}>
         <CenterContent>

--- a/apps/app/navigation/screens/onboardingScreen/OnboardingScreen.tsx
+++ b/apps/app/navigation/screens/onboardingScreen/OnboardingScreen.tsx
@@ -19,7 +19,8 @@ export default function OnboardingScreen({ navigation }) {
 
   return (
     <SafeAreaView style={tw`flex-auto`}>
-      <View style={tw`py-1.5 px-5 md:px-4`}>
+      {/* flex needed for Menu-overlay positioning */}
+      <View style={tw`flex items-start py-1.5 px-5 md:px-4`}>
         <AccountMenu
           openCreateWorkspace={() => {
             navigation.push("Onboarding");

--- a/apps/app/navigation/screens/workspaceNotFoundScreen/WorkspaceNotFoundScreen.tsx
+++ b/apps/app/navigation/screens/workspaceNotFoundScreen/WorkspaceNotFoundScreen.tsx
@@ -12,7 +12,8 @@ export default function WorkspaceNotFoundScreen({
 
   return (
     <SafeAreaView style={tw`flex-auto`}>
-      <View style={tw`py-1.5 px-5 md:px-4`}>
+      {/* flex needed for Menu-overlay positioning */}
+      <View style={tw`flex items-start py-1.5 px-5 md:px-4`}>
         <AccountMenu
           openCreateWorkspace={() => {
             navigation.push("Onboarding");

--- a/apps/app/navigation/screens/workspaceNotFoundScreen/WorkspaceNotFoundScreen.tsx
+++ b/apps/app/navigation/screens/workspaceNotFoundScreen/WorkspaceNotFoundScreen.tsx
@@ -1,63 +1,28 @@
-import {
-  StyleSheet,
-  TouchableOpacity,
-  useWindowDimensions,
-} from "react-native";
+import { KeyboardAvoidingView, useWindowDimensions } from "react-native";
 
-import { Text, View } from "@serenity-tools/ui";
+import { CenterContent, Link, Text, tw, View } from "@serenity-tools/ui";
+import { SafeAreaView } from "react-native-safe-area-context";
+import AccountMenu from "../../../components/accountMenu/AccountMenu";
 import { RootStackScreenProps } from "../../../types/navigation";
-import {
-  getLastUsedWorkspaceId,
-  removeLastUsedDocumentId,
-  removeLastUsedWorkspaceId,
-} from "../../../utils/lastUsedWorkspaceAndDocumentStore/lastUsedWorkspaceAndDocumentStore";
 
-export default function WorkspaceNotFoundScreen({
-  navigation,
-}: RootStackScreenProps<"NotFound">) {
+export default function WorkspaceNotFoundScreen({}: RootStackScreenProps<"NotFound">) {
   useWindowDimensions(); // needed to ensure tw-breakpoints are triggered when resizing
 
-  const removeLastUsedWorkspaceIdAndNavigateToRoot = async () => {
-    const workspaceId = await getLastUsedWorkspaceId();
-    if (workspaceId) {
-      removeLastUsedDocumentId(workspaceId);
-    }
-    await removeLastUsedWorkspaceId();
-    navigation.replace("Root");
-  };
-
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>
-        This workspace doesn't exist or you no longer have access.
-      </Text>
-      <TouchableOpacity
-        onPress={removeLastUsedWorkspaceIdAndNavigateToRoot}
-        style={styles.link}
-      >
-        <Text style={styles.linkText}>Go to home!</Text>
-      </TouchableOpacity>
-    </View>
+    <SafeAreaView style={tw`flex-auto`}>
+      <View style={tw`py-1.5 px-5 md:px-4`}>
+        <AccountMenu showCreateWorkspaceModal={() => undefined} />
+      </View>
+      <KeyboardAvoidingView behavior="padding" style={tw`flex-auto`}>
+        <CenterContent>
+          <Text style={tw`px-4`}>
+            This workspace doesn't exist or you no longer have access.
+          </Text>
+          <Link style={tw`mt-2`} to={{ screen: "Root" }}>
+            Go to home
+          </Link>
+        </CenterContent>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-    padding: 20,
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: "bold",
-  },
-  link: {
-    marginTop: 15,
-    paddingVertical: 15,
-  },
-  linkText: {
-    fontSize: 14,
-    color: "#2e78b7",
-  },
-});

--- a/apps/app/navigation/screens/workspaceNotFoundScreen/WorkspaceNotFoundScreen.tsx
+++ b/apps/app/navigation/screens/workspaceNotFoundScreen/WorkspaceNotFoundScreen.tsx
@@ -5,13 +5,19 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import AccountMenu from "../../../components/accountMenu/AccountMenu";
 import { RootStackScreenProps } from "../../../types/navigation";
 
-export default function WorkspaceNotFoundScreen({}: RootStackScreenProps<"NotFound">) {
+export default function WorkspaceNotFoundScreen({
+  navigation,
+}: RootStackScreenProps<"NotFound">) {
   useWindowDimensions(); // needed to ensure tw-breakpoints are triggered when resizing
 
   return (
     <SafeAreaView style={tw`flex-auto`}>
       <View style={tw`py-1.5 px-5 md:px-4`}>
-        <AccountMenu showCreateWorkspaceModal={() => undefined} />
+        <AccountMenu
+          openCreateWorkspace={() => {
+            navigation.push("Onboarding");
+          }}
+        />
       </View>
       <KeyboardAvoidingView behavior="padding" style={tw`flex-auto`}>
         <CenterContent>


### PR DESCRIPTION
- add account menu to onboarding screen
<img width="1064" alt="Screenshot 2022-10-06 at 08 55 32" src="https://user-images.githubusercontent.com/223045/194244333-399fecb5-ad88-41a9-b4de-2d47573171e7.png">

- add account menu to workspace not found screen
- fix redirect to workspace not found screen and polish it
<img width="1026" alt="Screenshot 2022-10-06 at 09 20 09" src="https://user-images.githubusercontent.com/223045/194244414-c75528b8-4006-4db5-8c22-10915fd45a50.png">

