### PR TITLE
Improve header styling & back button behaviour

### DIFF
--- a/apps/app/components/headerLeft/HeaderLeft.tsx
+++ b/apps/app/components/headerLeft/HeaderLeft.tsx
@@ -5,14 +5,10 @@ import { useWindowDimensions } from "react-native";
 
 type Props = {
   canGoBack: boolean;
-  defaultNavigate:
-    | "WorkspaceSettings"
-    | "AccountSettings"
-    | "WorkspaceRoot"
-    | "Root";
+  navigateTo?: "WorkspaceSettings" | "AccountSettings" | "WorkspaceRoot";
 };
 
-export function HeaderLeft({ canGoBack, defaultNavigate }: Props) {
+export function HeaderLeft({ canGoBack, navigateTo }: Props) {
   useWindowDimensions(); // needed to ensure tw-breakpoints are triggered when resizing
   const navigation = useNavigation();
   const route = useRoute();
@@ -22,28 +18,31 @@ export function HeaderLeft({ canGoBack, defaultNavigate }: Props) {
       <View style={tw`web:pl-3`}>
         <IconButton
           onPress={() => {
-            if (canGoBack) {
-              navigation.goBack();
-            } else {
-              // this case only happens if you directly navigate to a screen via a deep link on a mobile device
+            // When starting on a deep link you might run into a situation where
+            // goBack would be the wrong action. E.g. you start on a deep link
+            // in Account Device Settings. If you go back you would end up in
+            // Account Settings which is correct. But from there the goBack would
+            // back to Account Device Settings which is not correct.
+            // That's why we enforce back button navigation using the navigateTo
+            // props.
 
+            if (navigateTo) {
               // @ts-expect-error workspaceId is only defined in certain cases
               const workspaceId = route.params?.workspaceId || undefined;
-              if (defaultNavigate === "AccountSettings") {
+              if (navigateTo === "AccountSettings") {
                 navigation.navigate("AccountSettings");
-              } else if (
-                defaultNavigate === "WorkspaceSettings" &&
-                workspaceId
-              ) {
+              } else if (navigateTo === "WorkspaceSettings" && workspaceId) {
                 navigation.navigate("WorkspaceSettings", { workspaceId });
-              } else if (defaultNavigate === "WorkspaceRoot" && workspaceId) {
+              } else if (navigateTo === "WorkspaceRoot" && workspaceId) {
                 navigation.navigate("Workspace", {
                   workspaceId,
                   screen: "WorkspaceRoot",
                 });
-              } else {
-                navigation.navigate("Root");
               }
+            } else if (canGoBack) {
+              navigation.goBack();
+            } else {
+              navigation.navigate("Root");
             }
           }}
           name="arrow-left-line"

--- a/apps/app/components/headerLeft/HeaderLeft.tsx
+++ b/apps/app/components/headerLeft/HeaderLeft.tsx
@@ -1,0 +1,56 @@
+import { useNavigation, useRoute } from "@react-navigation/native";
+import { IconButton, tw, View } from "@serenity-tools/ui";
+import { HStack } from "native-base";
+import { useWindowDimensions } from "react-native";
+
+type Props = {
+  canGoBack: boolean;
+  defaultNavigate:
+    | "WorkspaceSettings"
+    | "AccountSettings"
+    | "WorkspaceRoot"
+    | "Root";
+};
+
+export function HeaderLeft({ canGoBack, defaultNavigate }: Props) {
+  useWindowDimensions(); // needed to ensure tw-breakpoints are triggered when resizing
+  const navigation = useNavigation();
+  const route = useRoute();
+
+  return (
+    <HStack alignItems={"center"}>
+      <View style={tw`web:pl-3`}>
+        <IconButton
+          onPress={() => {
+            if (canGoBack) {
+              navigation.goBack();
+            } else {
+              // this case only happens if you directly navigate to a screen via a deep link on a mobile device
+
+              // @ts-expect-error workspaceId is only defined in certain cases
+              const workspaceId = route.params?.workspaceId || undefined;
+              if (defaultNavigate === "AccountSettings") {
+                navigation.navigate("AccountSettings");
+              } else if (
+                defaultNavigate === "WorkspaceSettings" &&
+                workspaceId
+              ) {
+                navigation.navigate("WorkspaceSettings", { workspaceId });
+              } else if (defaultNavigate === "WorkspaceRoot" && workspaceId) {
+                navigation.navigate("Workspace", {
+                  workspaceId,
+                  screen: "WorkspaceRoot",
+                });
+              } else {
+                navigation.navigate("Root");
+              }
+            }
+          }}
+          name="arrow-left-line"
+          color={"gray-900"}
+          size={"lg"}
+        />
+      </View>
+    </HStack>
+  );
+}

--- a/apps/app/navigation/Navigation.tsx
+++ b/apps/app/navigation/Navigation.tsx
@@ -264,7 +264,12 @@ function RootNavigator() {
               options={{
                 headerTitle: "Profile",
                 headerLeft(props) {
-                  return <HeaderLeft {...props} navigateTo="AccountSettings" />;
+                  return (
+                    <HeaderLeft
+                      {...props}
+                      defaultNavigateTo="AccountSettings"
+                    />
+                  );
                 },
               }}
             />
@@ -274,7 +279,12 @@ function RootNavigator() {
               options={{
                 headerTitle: "Devices",
                 headerLeft(props) {
-                  return <HeaderLeft {...props} navigateTo="AccountSettings" />;
+                  return (
+                    <HeaderLeft
+                      {...props}
+                      defaultNavigateTo="AccountSettings"
+                    />
+                  );
                 },
               }}
             />
@@ -284,7 +294,9 @@ function RootNavigator() {
               options={{
                 headerTitle: "Workspace settings",
                 headerLeft(props) {
-                  return <HeaderLeft {...props} navigateTo="WorkspaceRoot" />;
+                  return (
+                    <HeaderLeft {...props} defaultNavigateTo="WorkspaceRoot" />
+                  );
                 },
               }}
             />
@@ -295,7 +307,10 @@ function RootNavigator() {
                 headerTitle: "General",
                 headerLeft(props) {
                   return (
-                    <HeaderLeft {...props} navigateTo="WorkspaceSettings" />
+                    <HeaderLeft
+                      {...props}
+                      defaultNavigateTo="WorkspaceSettings"
+                    />
                   );
                 },
               }}
@@ -307,7 +322,10 @@ function RootNavigator() {
                 headerTitle: "Members",
                 headerLeft(props) {
                   return (
-                    <HeaderLeft {...props} navigateTo="WorkspaceSettings" />
+                    <HeaderLeft
+                      {...props}
+                      defaultNavigateTo="WorkspaceSettings"
+                    />
                   );
                 },
               }}

--- a/apps/app/navigation/Navigation.tsx
+++ b/apps/app/navigation/Navigation.tsx
@@ -4,7 +4,6 @@ import {
   DefaultTheme,
   LinkingOptions,
   NavigationContainer,
-  useNavigation,
 } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { Text, tw, useIsPermanentLeftSidebar } from "@serenity-tools/ui";
@@ -197,16 +196,15 @@ const WorkspaceSettingsMembersScreenWithLoginRedirect =
     WorkspaceSettingsMembersScreen
   );
 
-function RootNavigator(props) {
+function RootNavigator() {
   const dimensions = useWindowDimensions();
-  const navigation = useNavigation();
 
   return (
     <Stack.Navigator
       screenOptions={{
         headerStyle: [styles.header],
         headerLeft(props) {
-          return <HeaderLeft {...props} defaultNavigate="Root" />;
+          return <HeaderLeft {...props} />;
         },
       }}
     >
@@ -258,15 +256,15 @@ function RootNavigator(props) {
             <Stack.Screen
               name="AccountSettings"
               component={AccountSettingsMobileOverviewScreenWithLoginRedirect}
+              options={{ headerTitle: "Account settings" }}
             />
             <Stack.Screen
               name="AccountSettingsProfile"
               component={AccountProfileSettingsScreenWithLoginRedirect}
               options={{
+                headerTitle: "Profile",
                 headerLeft(props) {
-                  return (
-                    <HeaderLeft {...props} defaultNavigate="AccountSettings" />
-                  );
+                  return <HeaderLeft {...props} navigateTo="AccountSettings" />;
                 },
               }}
             />
@@ -274,10 +272,9 @@ function RootNavigator(props) {
               name="AccountSettingsDevices"
               component={AccountDevicesSettingsScreenWithLoginRedirect}
               options={{
+                headerTitle: "Devices",
                 headerLeft(props) {
-                  return (
-                    <HeaderLeft {...props} defaultNavigate="AccountSettings" />
-                  );
+                  return <HeaderLeft {...props} navigateTo="AccountSettings" />;
                 },
               }}
             />
@@ -285,10 +282,9 @@ function RootNavigator(props) {
               name="WorkspaceSettings"
               component={WorkspaceSettingsMobileOverviewScreenWithLoginRedirect}
               options={{
+                headerTitle: "Workspace settings",
                 headerLeft(props) {
-                  return (
-                    <HeaderLeft {...props} defaultNavigate="WorkspaceRoot" />
-                  );
+                  return <HeaderLeft {...props} navigateTo="WorkspaceRoot" />;
                 },
               }}
             />
@@ -296,12 +292,10 @@ function RootNavigator(props) {
               name="WorkspaceSettingsGeneral"
               component={WorkspaceSettingsGeneralScreenWithLoginRedirect}
               options={{
+                headerTitle: "General",
                 headerLeft(props) {
                   return (
-                    <HeaderLeft
-                      {...props}
-                      defaultNavigate="WorkspaceSettings"
-                    />
+                    <HeaderLeft {...props} navigateTo="WorkspaceSettings" />
                   );
                 },
               }}
@@ -310,12 +304,10 @@ function RootNavigator(props) {
               name="WorkspaceSettingsMembers"
               component={WorkspaceSettingsMembersScreenWithLoginRedirect}
               options={{
+                headerTitle: "Members",
                 headerLeft(props) {
                   return (
-                    <HeaderLeft
-                      {...props}
-                      defaultNavigate="WorkspaceSettings"
-                    />
+                    <HeaderLeft {...props} navigateTo="WorkspaceSettings" />
                   );
                 },
               }}

--- a/apps/app/navigation/Navigation.tsx
+++ b/apps/app/navigation/Navigation.tsx
@@ -6,7 +6,12 @@ import {
   NavigationContainer,
 } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { Text, tw, useIsPermanentLeftSidebar } from "@serenity-tools/ui";
+import {
+  Heading,
+  Text,
+  tw,
+  useIsPermanentLeftSidebar,
+} from "@serenity-tools/ui";
 import * as Linking from "expo-linking";
 import { useEffect } from "react";
 import { ColorSchemeName, StyleSheet, useWindowDimensions } from "react-native";
@@ -106,7 +111,7 @@ function WorkspaceDrawerScreen(props) {
         <Drawer.Screen
           name="WorkspaceNotDecrypted"
           component={WorkspaceNotDecryptedScreen}
-          options={{ headerTitle: "" }}
+          options={{ title: "" }}
         />
         <Drawer.Screen
           name="WorkspaceRoot"
@@ -202,7 +207,8 @@ function RootNavigator() {
   return (
     <Stack.Navigator
       screenOptions={{
-        headerStyle: [styles.header],
+        headerStyle: styles.header,
+        headerTitle: (props) => <Heading lvl={3}>{props.children}</Heading>,
         headerLeft(props) {
           return <HeaderLeft {...props} />;
         },
@@ -256,13 +262,13 @@ function RootNavigator() {
             <Stack.Screen
               name="AccountSettings"
               component={AccountSettingsMobileOverviewScreenWithLoginRedirect}
-              options={{ headerTitle: "Account settings" }}
+              options={{ title: "Account settings" }}
             />
             <Stack.Screen
               name="AccountSettingsProfile"
               component={AccountProfileSettingsScreenWithLoginRedirect}
               options={{
-                headerTitle: "Profile",
+                title: "Profile",
                 headerLeft(props) {
                   return (
                     <HeaderLeft
@@ -277,7 +283,7 @@ function RootNavigator() {
               name="AccountSettingsDevices"
               component={AccountDevicesSettingsScreenWithLoginRedirect}
               options={{
-                headerTitle: "Devices",
+                title: "Devices",
                 headerLeft(props) {
                   return (
                     <HeaderLeft
@@ -292,7 +298,7 @@ function RootNavigator() {
               name="WorkspaceSettings"
               component={WorkspaceSettingsMobileOverviewScreenWithLoginRedirect}
               options={{
-                headerTitle: "Workspace settings",
+                title: "Workspace settings",
                 headerLeft(props) {
                   return (
                     <HeaderLeft {...props} defaultNavigateTo="WorkspaceRoot" />
@@ -304,7 +310,7 @@ function RootNavigator() {
               name="WorkspaceSettingsGeneral"
               component={WorkspaceSettingsGeneralScreenWithLoginRedirect}
               options={{
-                headerTitle: "General",
+                title: "General",
                 headerLeft(props) {
                   return (
                     <HeaderLeft
@@ -319,7 +325,7 @@ function RootNavigator() {
               name="WorkspaceSettingsMembers"
               component={WorkspaceSettingsMembersScreenWithLoginRedirect}
               options={{
-                headerTitle: "Members",
+                title: "Members",
                 headerLeft(props) {
                   return (
                     <HeaderLeft

--- a/apps/app/navigation/Navigation.tsx
+++ b/apps/app/navigation/Navigation.tsx
@@ -4,6 +4,7 @@ import {
   DefaultTheme,
   LinkingOptions,
   NavigationContainer,
+  useNavigation,
 } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { Text, tw, useIsPermanentLeftSidebar } from "@serenity-tools/ui";
@@ -11,6 +12,7 @@ import * as Linking from "expo-linking";
 import { useEffect } from "react";
 import { ColorSchemeName, StyleSheet, useWindowDimensions } from "react-native";
 import AccountSettingsSidebar from "../components/accountSettingsSidebar/AccountSettingsSidebar";
+import { HeaderLeft } from "../components/headerLeft/HeaderLeft";
 import NavigationDrawerModal from "../components/navigationDrawerModal/NavigationDrawerModal";
 import { PageHeaderLeft } from "../components/pageHeaderLeft/PageHeaderLeft";
 import Sidebar from "../components/sidebar/Sidebar";
@@ -195,13 +197,17 @@ const WorkspaceSettingsMembersScreenWithLoginRedirect =
     WorkspaceSettingsMembersScreen
   );
 
-function RootNavigator() {
+function RootNavigator(props) {
   const dimensions = useWindowDimensions();
+  const navigation = useNavigation();
 
   return (
     <Stack.Navigator
       screenOptions={{
         headerStyle: [styles.header],
+        headerLeft(props) {
+          return <HeaderLeft {...props} defaultNavigate="Root" />;
+        },
       }}
     >
       <Stack.Group>
@@ -256,22 +262,63 @@ function RootNavigator() {
             <Stack.Screen
               name="AccountSettingsProfile"
               component={AccountProfileSettingsScreenWithLoginRedirect}
+              options={{
+                headerLeft(props) {
+                  return (
+                    <HeaderLeft {...props} defaultNavigate="AccountSettings" />
+                  );
+                },
+              }}
             />
             <Stack.Screen
               name="AccountSettingsDevices"
               component={AccountDevicesSettingsScreenWithLoginRedirect}
+              options={{
+                headerLeft(props) {
+                  return (
+                    <HeaderLeft {...props} defaultNavigate="AccountSettings" />
+                  );
+                },
+              }}
             />
             <Stack.Screen
               name="WorkspaceSettings"
               component={WorkspaceSettingsMobileOverviewScreenWithLoginRedirect}
+              options={{
+                headerLeft(props) {
+                  return (
+                    <HeaderLeft {...props} defaultNavigate="WorkspaceRoot" />
+                  );
+                },
+              }}
             />
             <Stack.Screen
               name="WorkspaceSettingsGeneral"
               component={WorkspaceSettingsGeneralScreenWithLoginRedirect}
+              options={{
+                headerLeft(props) {
+                  return (
+                    <HeaderLeft
+                      {...props}
+                      defaultNavigate="WorkspaceSettings"
+                    />
+                  );
+                },
+              }}
             />
             <Stack.Screen
               name="WorkspaceSettingsMembers"
               component={WorkspaceSettingsMembersScreenWithLoginRedirect}
+              options={{
+                headerLeft(props) {
+                  return (
+                    <HeaderLeft
+                      {...props}
+                      defaultNavigate="WorkspaceSettings"
+                    />
+                  );
+                },
+              }}
             />
           </>
         ) : null}

--- a/apps/app/navigation/Navigation.tsx
+++ b/apps/app/navigation/Navigation.tsx
@@ -199,7 +199,11 @@ function RootNavigator() {
   const dimensions = useWindowDimensions();
 
   return (
-    <Stack.Navigator>
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: [styles.header],
+      }}
+    >
       <Stack.Group>
         <Stack.Screen
           name="Root"

--- a/apps/app/navigation/Navigation.tsx
+++ b/apps/app/navigation/Navigation.tsx
@@ -270,12 +270,7 @@ function RootNavigator() {
               options={{
                 title: "Profile",
                 headerLeft(props) {
-                  return (
-                    <HeaderLeft
-                      {...props}
-                      defaultNavigateTo="AccountSettings"
-                    />
-                  );
+                  return <HeaderLeft {...props} navigateTo="AccountSettings" />;
                 },
               }}
             />
@@ -285,12 +280,7 @@ function RootNavigator() {
               options={{
                 title: "Devices",
                 headerLeft(props) {
-                  return (
-                    <HeaderLeft
-                      {...props}
-                      defaultNavigateTo="AccountSettings"
-                    />
-                  );
+                  return <HeaderLeft {...props} navigateTo="AccountSettings" />;
                 },
               }}
             />
@@ -299,11 +289,6 @@ function RootNavigator() {
               component={WorkspaceSettingsMobileOverviewScreenWithLoginRedirect}
               options={{
                 title: "Workspace settings",
-                headerLeft(props) {
-                  return (
-                    <HeaderLeft {...props} defaultNavigateTo="WorkspaceRoot" />
-                  );
-                },
               }}
             />
             <Stack.Screen
@@ -313,10 +298,7 @@ function RootNavigator() {
                 title: "General",
                 headerLeft(props) {
                   return (
-                    <HeaderLeft
-                      {...props}
-                      defaultNavigateTo="WorkspaceSettings"
-                    />
+                    <HeaderLeft {...props} navigateTo="WorkspaceSettings" />
                   );
                 },
               }}
@@ -328,10 +310,7 @@ function RootNavigator() {
                 title: "Members",
                 headerLeft(props) {
                   return (
-                    <HeaderLeft
-                      {...props}
-                      defaultNavigateTo="WorkspaceSettings"
-                    />
+                    <HeaderLeft {...props} navigateTo="WorkspaceSettings" />
                   );
                 },
               }}

--- a/apps/app/types/navigation.ts
+++ b/apps/app/types/navigation.ts
@@ -81,7 +81,7 @@ export type RootStackParamList = {
   Login: LoginParams;
   EncryptDecryptImageTest: undefined;
   TestLibsodium: undefined;
-  AccountSettings: AccountSettingsParams;
+  AccountSettings: AccountSettingsParams | undefined;
   AccountSettingsProfile: undefined; // on phones
   AccountSettingsDevices: undefined; // on phones
   WorkspaceSettingsGeneral: undefined; // on phones


### PR DESCRIPTION
New header styling which now is aligned with the Figma design and applied across all Platforms.
Only difference left which might make sense since it's Platform default: On iOS the title is centered and on all other Platforms left aligned. Thoughts @freuleinkorksi?

iOS
<img width="390" alt="Screenshot 2022-10-07 at 08 44 37" src="https://user-images.githubusercontent.com/223045/194485260-2645a557-c8dc-4f7a-a035-76da4f9fca19.png">

Web:
<img width="482" alt="Screenshot 2022-10-07 at 08 44 48" src="https://user-images.githubusercontent.com/223045/194484808-c7649913-c4c0-4fd0-af12-4657be017fff.png">
<img width="708" alt="Screenshot 2022-10-07 at 08 44 56" src="https://user-images.githubusercontent.com/223045/194484814-9d4392d7-4a64-4957-8ab6-5bf26915a614.png">
