### PR TITLE
Fix toolbar position & improve scroll into view & make editing work in Safari (desktop & iOS)

### DIFF
--- a/apps/app/App.tsx
+++ b/apps/app/App.tsx
@@ -21,9 +21,11 @@ import { AppContextProvider } from "./context/AppContext";
 import useCachedResources from "./hooks/useCachedResources";
 import Navigation from "./navigation/Navigation";
 import { patchConsoleOutput } from "./utils/patchConsoleOutput/patchConsoleOutput";
+import { patchGlobalStyles } from "./utils/patchGlobalStyles/patchGlobalStyles";
 import { source } from "./webviews/opaque/source";
 
 patchConsoleOutput();
+patchGlobalStyles();
 
 // import { clearDeviceAndSessionStorage } from "./utils/authentication/clearDeviceAndSessionStorage";
 // clearDeviceAndSessionStorage();

--- a/apps/app/components/editor/Editor.tsx
+++ b/apps/app/components/editor/Editor.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useRef, useState } from "react";
-import { Animated, Keyboard, useWindowDimensions } from "react-native";
+import { Animated, Keyboard } from "react-native";
 import { WebView } from "react-native-webview";
 // import { Asset } from "expo-asset";
 // import * as FileSystem from "expo-file-system";
-import { useHeaderHeight } from "@react-navigation/elements";
 import {
   EditorBottombarState,
   UpdateEditorParams,
@@ -79,11 +78,6 @@ export default function Editor({
   // leveraging a ref here since the injectedJavaScriptBeforeContentLoaded
   // seem to not inject the initial isNew, but the current value
   const isNewRef = useRef<boolean>(isNew);
-  const dimensions = useWindowDimensions();
-  const headerHeight = useHeaderHeight();
-
-  const editorHeight = dimensions.height - headerHeight;
-
   const [isEditorBottombarVisible, setIsEditorBottombarVisible] =
     useState(false);
   const hasEditorSidebar = useHasEditorSidebar();
@@ -211,8 +205,6 @@ export default function Editor({
             setEditorBottombarState(message.content);
           }
         }}
-        // style={[tw`flex-auto bg-primary-200`]}
-        // containerStyle={{ flex: 0, height: editorHeight }}
         // Needed for .focus() to work
         keyboardDisplayRequiresUserAction={false}
         injectedJavaScriptBeforeContentLoaded={`
@@ -220,7 +212,6 @@ export default function Editor({
           window.initialContent = ${JSON.stringify(
             Array.apply([], Y.encodeStateAsUpdateV2(yDocRef.current))
           )};
-          window.editorHeight = ${editorHeight};
           true; // this is required, or you'll sometimes get silent failures
         `}
         onLoad={() => {

--- a/apps/app/components/editor/Editor.tsx
+++ b/apps/app/components/editor/Editor.tsx
@@ -174,7 +174,7 @@ export default function Editor({
         // avoid showing the form next/prev & Done button on iOS
         // when the keyboard is shown
         hideKeyboardAccessoryView={true}
-        scrollEnabled={true}
+        scrollEnabled={false}
         renderLoading={() => (
           <CenterContent>
             <Spinner fadeIn size="lg" />

--- a/apps/app/components/editor/Editor.web.tsx
+++ b/apps/app/components/editor/Editor.web.tsx
@@ -33,7 +33,7 @@ export default function Editor({
   const editorBottombarWrapperRef = useRef<RNView>(null);
   const editorIsFocusedRef = useRef<boolean>(false);
 
-  const showAndPositionToolbar = function () {
+  const positionToolbar = () => {
     if (editorBottombarWrapperRef.current && editorIsFocusedRef.current) {
       const topPos =
         // @ts-expect-error - works in web only
@@ -44,6 +44,12 @@ export default function Editor({
         2;
       // @ts-expect-error - this is a div
       editorBottombarWrapperRef.current.style.top = `${topPos}px`;
+    }
+  };
+
+  const showAndPositionToolbar = function () {
+    if (editorBottombarWrapperRef.current && editorIsFocusedRef.current) {
+      positionToolbar();
       // @ts-expect-error - this is a div
       editorBottombarWrapperRef.current.style.display = "block";
     }
@@ -52,13 +58,16 @@ export default function Editor({
   useEffect(() => {
     // @ts-expect-error - works in web only
     window.visualViewport.addEventListener("resize", showAndPositionToolbar);
+    window.addEventListener("scroll", positionToolbar);
 
-    return () =>
+    return () => {
       // @ts-expect-error - works in web only
       window.visualViewport.removeEventListener(
         "resize",
         showAndPositionToolbar
       );
+      window.removeEventListener("scroll", positionToolbar);
+    };
   }, []);
 
   return (
@@ -91,7 +100,9 @@ export default function Editor({
               }
             }
           }}
-          onCreate={(params) => (tipTapEditorRef.current = params.editor)}
+          onCreate={(params) => {
+            tipTapEditorRef.current = params.editor;
+          }}
           onTransaction={(params) => {
             setEditorBottombarState(
               getEditorBottombarStateFromEditor(params.editor)

--- a/apps/app/components/editor/Editor.web.tsx
+++ b/apps/app/components/editor/Editor.web.tsx
@@ -1,4 +1,3 @@
-import { useHeaderHeight } from "@react-navigation/elements";
 import {
   Editor as SerenityEditor,
   EditorBottombarState,
@@ -24,7 +23,6 @@ export default function Editor({
   isNew,
   updateTitle,
 }: EditorProps) {
-  const headerHeight = useHeaderHeight();
   const [editorBottombarState, setEditorBottombarState] =
     useState<EditorBottombarState>(initialEditorBottombarState);
   const tipTapEditorRef = useRef<TipTapEditor | null>(null);
@@ -38,9 +36,9 @@ export default function Editor({
       const topPos =
         // @ts-expect-error - works in web only
         window.visualViewport.height +
-        window.pageYOffset - // needed for iOS safari scroll page offset
+        window.scrollY - // needed for iOS safari scroll page offset
         editorBottombarHeight -
-        headerHeight +
+        48 + // header height (top-bar) since it's 3 rem
         2;
       // @ts-expect-error - this is a div
       editorBottombarWrapperRef.current.style.top = `${topPos}px`;

--- a/apps/app/utils/patchGlobalStyles/patchGlobalStyles.ts
+++ b/apps/app/utils/patchGlobalStyles/patchGlobalStyles.ts
@@ -1,0 +1,1 @@
+export const patchGlobalStyles = () => {};

--- a/apps/app/utils/patchGlobalStyles/patchGlobalStyles.web.ts
+++ b/apps/app/utils/patchGlobalStyles/patchGlobalStyles.web.ts
@@ -1,0 +1,15 @@
+export const patchGlobalStyles = () => {
+  // this fixes a bug in react navigation that prevented users to select
+  // text in the web version and even editing in Safari (desktop & iOS).
+  //
+  // Once this issue is resolved we can remove this patch
+  // https://github.com/react-navigation/react-navigation/issues/10922
+  const style = document.createElement("style");
+  style.textContent = `
+  * {
+    user-select: auto !important;
+    -webkit-user-select: auto !important;
+  }
+`;
+  document.head.appendChild(style);
+};

--- a/apps/backend/test/e2e/workspace/folderAccessControl.e2e.ts
+++ b/apps/backend/test/e2e/workspace/folderAccessControl.e2e.ts
@@ -1,4 +1,4 @@
-import { Page, test } from "@playwright/test";
+import { expect, Page, test } from "@playwright/test";
 import * as sodium from "@serenity-tools/libsodium";
 import { v4 as uuidv4 } from "uuid";
 import createUserWithWorkspace from "../../../src/database/testHelpers/createUserWithWorkspace";

--- a/packages/common/src/debounce/debounce.ts
+++ b/packages/common/src/debounce/debounce.ts
@@ -1,0 +1,9 @@
+export function debounce<
+  Func extends (...args: Parameters<Func>) => ReturnType<Func>
+>(func: Func, waitFor: number): (...args: Parameters<Func>) => void {
+  let timeout: NodeJS.Timeout;
+  return (...args: Parameters<Func>): void => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func(...args), waitFor);
+  };
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -3,6 +3,7 @@ export * from "./createDevice/createDevice";
 export * from "./createDocumentKey/createDocumentKey";
 export * from "./createEncryptionKeyFromOpaqueExportKey/createEncryptionKeyFromOpaqueExportKey";
 export * from "./createIntroductionDocumentSnapshot/createIntroductionDocumentSnapshot";
+export * from "./debounce/debounce";
 export * from "./decryptDevice/decryptDevice";
 export * from "./decryptDocumentTitle/decryptDocumentTitle";
 export * from "./decryptFolderName/decryptFolderName";

--- a/packages/editor/Editor.tsx
+++ b/packages/editor/Editor.tsx
@@ -22,7 +22,7 @@ type EditorProps = {
   yDocRef: React.MutableRefObject<Y.Doc>;
   yAwarenessRef: React.MutableRefObject<Awareness>;
   isNew?: boolean;
-  editorHeight?: number;
+  scrollIntoViewOnEditModeDelay?: number;
   openDrawer: () => void;
   updateTitle: (title: string) => void;
   onTransaction?: (params: EditorEvents["transaction"]) => void;
@@ -39,6 +39,8 @@ export const Editor = (props: EditorProps) => {
   const [isNew] = useState(props.isNew ?? false);
   const newTitleRef = useRef("");
   const shouldCommitNewTitleRef = useRef(isNew);
+  const scrollIntoViewOnEditModeDelay =
+    props.scrollIntoViewOnEditModeDelay ?? 150; // 150ms works well on iOS Safari
 
   const editor = useEditor(
     {
@@ -130,7 +132,7 @@ export const Editor = (props: EditorProps) => {
         // before we scroll into view
         setTimeout(() => {
           params.editor.chain().scrollIntoViewOnEditMode().run();
-        }, 50);
+        }, scrollIntoViewOnEditModeDelay);
       },
       onBlur: (params) => {
         if (props.onBlur) {
@@ -146,9 +148,11 @@ export const Editor = (props: EditorProps) => {
       <View style={tw`flex-auto text-gray-900 dark:text-white`}>
         <div className="flex-auto overflow-y-auto overflow-x-hidden">
           <EditorContent
-            // 100% needed to expand the editor to it's full height even when empty
             style={{
-              height: props.editorHeight ?? undefined,
+              // needed to expand the editor into the unsafe area
+              // on iOS native App in case the client is not in edit mode
+              // to make sure the content expands till the bottom
+              height: "-webkit-fill-available",
             }}
             editor={editor}
             className={

--- a/packages/editor/Editor.tsx
+++ b/packages/editor/Editor.tsx
@@ -15,7 +15,7 @@ import "./awareness.css";
 import EditorSidebar from "./components/editorSidebar/EditorSidebar";
 import "./editor-output.css";
 import { AwarnessExtension } from "./naisho-awareness-extension";
-import { SerenityScrollIntoViewExtension } from "./scroll-into-view-extensions";
+import { SerenityScrollIntoViewOnEditModeExtension } from "./scroll-into-view-on-edit-mode-extensions";
 
 type EditorProps = {
   documentId: string;
@@ -90,7 +90,7 @@ export const Editor = (props: EditorProps) => {
         AwarnessExtension.configure({
           awareness: props.yAwarenessRef.current,
         }),
-        SerenityScrollIntoViewExtension.configure({}),
+        SerenityScrollIntoViewOnEditModeExtension.configure({}),
       ],
       onCreate: (params) => {
         if (isNew) {
@@ -129,7 +129,7 @@ export const Editor = (props: EditorProps) => {
         // timeout to make sure the selection has time to be set
         // before we scroll into view
         setTimeout(() => {
-          params.editor.chain().scrollIntoView().run();
+          params.editor.chain().scrollIntoViewOnEditMode().run();
         }, 50);
       },
       onBlur: (params) => {

--- a/packages/editor/Editor.tsx
+++ b/packages/editor/Editor.tsx
@@ -126,6 +126,11 @@ export const Editor = (props: EditorProps) => {
         if (props.onFocus) {
           props.onFocus(params);
         }
+        // timeout to make sure the selection has time to be set
+        // before we scroll into view
+        setTimeout(() => {
+          params.editor.chain().scrollIntoView().run();
+        }, 50);
       },
       onBlur: (params) => {
         if (props.onBlur) {
@@ -143,9 +148,12 @@ export const Editor = (props: EditorProps) => {
           <EditorContent
             // 100% needed to expand the editor to it's full height even when empty
             style={{
-              height: props.editorHeight ?? "100%",
+              height: props.editorHeight ?? undefined,
             }}
             editor={editor}
+            className={
+              hasEditorSidebar ? "has-editor-sidebar" : "has-editor-bottombar"
+            }
           />
         </div>
       </View>

--- a/packages/editor/Editor.tsx
+++ b/packages/editor/Editor.tsx
@@ -1,21 +1,21 @@
-import "./editor-output.css";
-import "./awareness.css";
-import React, { useRef, useState } from "react";
-import { useEditor, EditorContent } from "@tiptap/react";
 import { tw, useHasEditorSidebar, View } from "@serenity-tools/ui";
-import StarterKit from "@tiptap/starter-kit";
-import Link from "@tiptap/extension-link";
-import { Level } from "@tiptap/extension-heading";
+import { EditorEvents } from "@tiptap/core";
 import Collaboration from "@tiptap/extension-collaboration";
-import * as Y from "yjs";
+import { Level } from "@tiptap/extension-heading";
+import Link from "@tiptap/extension-link";
+import Placeholder from "@tiptap/extension-placeholder";
+import TaskItem from "@tiptap/extension-task-item";
+import TaskList from "@tiptap/extension-task-list";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import React, { useRef, useState } from "react";
 import { Awareness } from "y-protocols/awareness";
+import * as Y from "yjs";
+import "./awareness.css";
+import EditorSidebar from "./components/editorSidebar/EditorSidebar";
+import "./editor-output.css";
 import { AwarnessExtension } from "./naisho-awareness-extension";
 import { SerenityScrollIntoViewExtension } from "./scroll-into-view-extensions";
-import TaskList from "@tiptap/extension-task-list";
-import TaskItem from "@tiptap/extension-task-item";
-import Placeholder from "@tiptap/extension-placeholder";
-import EditorSidebar from "./components/editorSidebar/EditorSidebar";
-import { EditorEvents } from "@tiptap/core";
 
 type EditorProps = {
   documentId: string;

--- a/packages/editor/Editor.tsx
+++ b/packages/editor/Editor.tsx
@@ -10,6 +10,7 @@ import Collaboration from "@tiptap/extension-collaboration";
 import * as Y from "yjs";
 import { Awareness } from "y-protocols/awareness";
 import { AwarnessExtension } from "./naisho-awareness-extension";
+import { SerenityScrollIntoViewExtension } from "./scroll-into-view-extensions";
 import TaskList from "@tiptap/extension-task-list";
 import TaskItem from "@tiptap/extension-task-item";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -89,6 +90,7 @@ export const Editor = (props: EditorProps) => {
         AwarnessExtension.configure({
           awareness: props.yAwarenessRef.current,
         }),
+        SerenityScrollIntoViewExtension.configure({}),
       ],
       onCreate: (params) => {
         if (isNew) {

--- a/packages/editor/editor-input.css
+++ b/packages/editor/editor-input.css
@@ -43,6 +43,10 @@
     @apply pb-10 md:pb-14;
   }
 
+  .has-editor-bottombar .ProseMirror > *:last-child {
+    @apply pb-96; /* space for the keyboard on mobile */
+  }
+
   /* needed to make all area of the editor clickable which enables activating the cursor on each written line */
   .ProseMirror > * {
     @apply mx-auto w-full max-w-prose-rem;

--- a/packages/editor/scroll-into-view-extensions.ts
+++ b/packages/editor/scroll-into-view-extensions.ts
@@ -11,20 +11,29 @@ export const SerenityScrollIntoViewExtension = Extension.create<
   name: "serenityScrollIntoViewExtension",
 
   addCommands() {
-    alert("add COMMANDS");
     return {
       scrollIntoView:
         () =>
-        ({ commands }) => {
-          let { from, to } = this.editor.state.selection;
-          // let start = this.editor.view.coordsAtPos(from);
-          let end = this.editor.view.coordsAtPos(to);
-          alert("scrollIntoView");
-          this.editor.view.dom.parentElement?.parentElement?.scrollTo(
-            0,
-            end.top + 200 // covers the editor toolbar plus some space to not end up at the very bottom
-          );
-          return true;
+        ({ commands, editor }) => {
+          const { from, to } = editor.state.selection;
+
+          const end = editor.view.coordsAtPos(to);
+
+          const editorBoundaries = editor.view.dom.getBoundingClientRect();
+          console.log("end", end);
+
+          // only scroll if it's below the keynboard + toolbar
+          if (end.top > editorBoundaries.height - 352 - 50) {
+            const scrollTop =
+              editor.view.dom.parentElement?.parentElement?.scrollTop || 0;
+
+            editor.view.dom.parentElement?.parentElement?.scrollTo({
+              // covers the editor toolbar plus some space to not end up at the very bottom
+              top: end.top + scrollTop - 300,
+              behavior: "smooth", // jfyi not supported on iOS Safari
+            });
+            return true;
+          }
         },
     };
   },

--- a/packages/editor/scroll-into-view-extensions.ts
+++ b/packages/editor/scroll-into-view-extensions.ts
@@ -34,6 +34,7 @@ export const SerenityScrollIntoViewExtension = Extension.create<
             });
             return true;
           }
+          return true;
         },
     };
   },

--- a/packages/editor/scroll-into-view-extensions.ts
+++ b/packages/editor/scroll-into-view-extensions.ts
@@ -1,0 +1,30 @@
+import { Extension } from "@tiptap/core";
+
+export interface ExtensionOptions {}
+
+type Storage = {};
+
+export const SerenityScrollIntoViewExtension = Extension.create<
+  ExtensionOptions,
+  Storage
+>({
+  name: "serenityScrollIntoViewExtension",
+
+  addCommands() {
+    return {
+      scrollIntoView:
+        () =>
+        ({ commands }) => {
+          let { from, to } = this.editor.state.selection;
+          console.log("scrollIntoView");
+          // let start = this.editor.view.coordsAtPos(from);
+          let end = this.editor.view.coordsAtPos(to);
+          this.editor.view.dom.parentElement?.parentElement?.scrollTo(
+            0,
+            end.top
+          );
+          return true;
+        },
+    };
+  },
+});

--- a/packages/editor/scroll-into-view-extensions.ts
+++ b/packages/editor/scroll-into-view-extensions.ts
@@ -11,17 +11,18 @@ export const SerenityScrollIntoViewExtension = Extension.create<
   name: "serenityScrollIntoViewExtension",
 
   addCommands() {
+    alert("add COMMANDS");
     return {
       scrollIntoView:
         () =>
         ({ commands }) => {
           let { from, to } = this.editor.state.selection;
-          console.log("scrollIntoView");
           // let start = this.editor.view.coordsAtPos(from);
           let end = this.editor.view.coordsAtPos(to);
+          alert("scrollIntoView");
           this.editor.view.dom.parentElement?.parentElement?.scrollTo(
             0,
-            end.top
+            end.top + 200 // covers the editor toolbar plus some space to not end up at the very bottom
           );
           return true;
         },

--- a/packages/editor/scroll-into-view-on-edit-mode-extensions.ts
+++ b/packages/editor/scroll-into-view-on-edit-mode-extensions.ts
@@ -4,15 +4,32 @@ export interface ExtensionOptions {}
 
 type Storage = {};
 
-export const SerenityScrollIntoViewExtension = Extension.create<
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    customExtension: {
+      scrollIntoViewOnEditMode: () => ReturnType;
+    };
+  }
+}
+
+const isIos = [
+  "iPad Simulator",
+  "iPhone Simulator",
+  "iPod Simulator",
+  "iPad",
+  "iPhone",
+  "iPod",
+].includes(navigator.platform);
+
+export const SerenityScrollIntoViewOnEditModeExtension = Extension.create<
   ExtensionOptions,
   Storage
 >({
-  name: "serenityScrollIntoViewExtension",
+  name: "serenityScrollIntoViewOnEditModeExtension",
 
   addCommands() {
     return {
-      scrollIntoView:
+      scrollIntoViewOnEditMode:
         () =>
         ({ commands, editor }) => {
           const { from, to } = editor.state.selection;
@@ -22,8 +39,12 @@ export const SerenityScrollIntoViewExtension = Extension.create<
           const editorBoundaries = editor.view.dom.getBoundingClientRect();
           console.log("end", end);
 
-          // only scroll if it's below the keynboard + toolbar
-          if (end.top > editorBoundaries.height - 352 - 50) {
+          // only scroll if it's below the keyboard + toolbar
+          if (
+            isIos
+              ? end.top > editorBoundaries.height - 352 - 50
+              : end.top > editorBoundaries.height - 50
+          ) {
             const scrollTop =
               editor.view.dom.parentElement?.parentElement?.scrollTop || 0;
 

--- a/packages/editor/standalone.tsx
+++ b/packages/editor/standalone.tsx
@@ -77,13 +77,13 @@ const domContainer = document.querySelector("#editor");
 ReactDOM.render(
   <NativeBaseProvider>
     <Editor
+      scrollIntoViewOnEditModeDelay={50}
       documentId={"dummyDocumentId"}
       yDocRef={{ current: ydoc }}
       yAwarenessRef={{ current: yAwareness }}
       openDrawer={openDrawer}
       updateTitle={updateTitle}
       isNew={window.isNew}
-      editorHeight={window.editorHeight}
       onCreate={(params) => (window.editor = params.editor)}
       onTransaction={({ editor }) => {
         window.ReactNativeWebView.postMessage(

--- a/packages/editor/standalone.tsx
+++ b/packages/editor/standalone.tsx
@@ -1,17 +1,16 @@
+import { NativeBaseProvider } from "native-base";
 import React from "react";
 import ReactDOM from "react-dom";
-import { NativeBaseProvider } from "native-base";
-import { Editor } from "./Editor";
-import * as Y from "yjs";
 import {
+  applyAwarenessUpdate,
   Awareness,
   encodeAwarenessUpdate,
-  applyAwarenessUpdate,
-  removeAwarenessStates,
 } from "y-protocols/awareness";
+import * as Y from "yjs";
+import { Editor } from "./Editor";
+import { getEditorBottombarStateFromEditor } from "./getEditorBottombarStateFromEditor";
 import { UpdateEditorParams } from "./types";
 import { updateEditor } from "./updateEditor";
-import { getEditorBottombarStateFromEditor } from "./getEditorBottombarStateFromEditor";
 
 const ydoc = new Y.Doc();
 window.ydoc = ydoc;

--- a/packages/editor/types.ts
+++ b/packages/editor/types.ts
@@ -68,7 +68,6 @@ declare global {
     ydoc: any;
     editor: any;
     isNew: boolean;
-    editorHeight: number;
     initialContent: any;
     updateEditor: (paramsString: string) => void;
     applyYjsUpdate: (update: any) => void;


### PR DESCRIPTION
## Devices checked

- iPhone Safari
- iPhone App
    - In non-edit mode the editor area must expand to the bottom (incl non-safe area) - to be tested with a long document
- Chrome

## Scroll Cases

- Only scroll if virtual keyboard is popping up or bottom bar is active
- Don’t scroll when above the fold (virtual keyboard)
- Scroll down, then click on an item above the scroll fold (should not scroll)
- Scroll down, then click on an item below the scroll fold (should scroll)
- Click mutiple times on the same position (should only scroll the first time)
- Empty document still expands to full height and goes into edit mode when I click anywhere in the white area