### PR TITLE
Use activeDevice signatures, show user email and refactor Page

### DIFF
--- a/apps/app/components/page/Page.tsx
+++ b/apps/app/components/page/Page.tsx
@@ -38,6 +38,7 @@ import {
   DocumentQuery,
   DocumentQueryVariables,
 } from "../../generated/graphql";
+import { fetchMe } from "../../graphql/fetchUtils/fetchMe";
 import { useWorkspaceContext } from "../../hooks/useWorkspaceContext";
 import { WorkspaceDrawerScreenProps } from "../../types/navigation";
 import { useActiveDocumentInfoStore } from "../../utils/document/activeDocumentInfoStore";
@@ -187,8 +188,10 @@ export default function Page({
     async function initDocument() {
       await sodium.ready;
 
+      const me = await fetchMe();
+
       yAwarenessRef.current.setLocalStateField("user", {
-        name: `User ${yDocRef.current.clientID}`,
+        name: me.data?.me?.username ?? "Unknown user",
       });
 
       const documentResult = await getUrqlClient()

--- a/apps/app/components/page/Page.tsx
+++ b/apps/app/components/page/Page.tsx
@@ -63,7 +63,6 @@ export default function Page({
     throw new Error("Page ID was not set");
   }
   const docId = route.params.pageId;
-  // const workspaceId = route.params.workspaceId;
   const isNew = route.params.isNew ?? false;
   const { activeDevice } = useWorkspaceContext();
   const activeSnapshotIdRef = useRef<string | null>(null);

--- a/apps/app/components/page/Page.tsx
+++ b/apps/app/components/page/Page.tsx
@@ -42,13 +42,7 @@ import {
 import { useWorkspaceContext } from "../../hooks/useWorkspaceContext";
 import { WorkspaceDrawerScreenProps } from "../../types/navigation";
 import { useActiveDocumentInfoStore } from "../../utils/document/activeDocumentInfoStore";
-import {
-  getDocumentPath,
-  useDocumentPathStore,
-} from "../../utils/document/documentPathStore";
 import { useFolderKeyStore } from "../../utils/folder/folderKeyStore";
-// import { getFolderKey } from "../../utils/folder/getFolderKey";
-import { useOpenFolderStore } from "../../utils/folder/openFolderStore";
 import { getUrqlClient } from "../../utils/urqlClient/urqlClient";
 
 const reconnectTimeout = 2000;
@@ -77,35 +71,10 @@ export default function Page({ navigation, route, updateTitle }: Props) {
   const editorInitializedRef = useRef<boolean>(false);
   const websocketState = useWebsocketState();
 
-  const docIdRef = useRef<string | null>(null);
-  const folderStore = useOpenFolderStore();
-  const documentPathStore = useDocumentPathStore();
   const updateActiveDocumentInfoStore = useActiveDocumentInfoStore(
     (state) => state.update
   );
   const getFolderKey = useFolderKeyStore((state) => state.getFolderKey);
-
-  const updateDocumentFolderPath = async (docId: string) => {
-    const documentPath = await getDocumentPath(docId);
-    const openFolderIds = folderStore.folderIds;
-    if (!documentPath) {
-      return;
-    }
-    documentPath.forEach((folder) => {
-      if (folder) {
-        openFolderIds.push(folder.id);
-      }
-    });
-    folderStore.update(openFolderIds);
-    documentPathStore.update(documentPath, activeDevice);
-  };
-
-  useEffect(() => {
-    if (docIdRef.current !== docId) {
-      updateDocumentFolderPath(docId);
-    }
-    docIdRef.current = docId;
-  });
 
   const applySnapshot = async (snapshot, key) => {
     try {
@@ -220,12 +189,6 @@ export default function Page({ navigation, route, updateTitle }: Props) {
       yAwarenessRef.current.setLocalStateField("user", {
         name: `User ${yDocRef.current.clientID}`,
       });
-
-      // TODO get key from navigation
-      // const key = sodium.from_base64(window.location.hash.slice(1));
-      // const key = sodium.from_base64(
-      //   "cksJKBDshtfjXJ0GdwKzHvkLxDp7WYYmdJkU1qPgM-0"
-      // );
 
       const documentResult = await getUrqlClient()
         .query<DocumentQuery, DocumentQueryVariables>(

--- a/apps/app/navigation/screens/pageScreen/PageScreen.tsx
+++ b/apps/app/navigation/screens/pageScreen/PageScreen.tsx
@@ -3,7 +3,7 @@ import {
   encryptDocumentTitle,
   recreateDocumentKey,
 } from "@serenity-tools/common";
-import { useEffect, useLayoutEffect } from "react";
+import { useEffect, useLayoutEffect, useMemo } from "react";
 import { useWindowDimensions } from "react-native";
 import Page from "../../../components/page/Page";
 import { PageHeader } from "../../../components/page/PageHeader";
@@ -16,6 +16,7 @@ import {
 import { useWorkspaceContext } from "../../../hooks/useWorkspaceContext";
 import { WorkspaceDrawerScreenProps } from "../../../types/navigation";
 
+import sodium, { KeyPair } from "@serenity-tools/libsodium";
 import { CenterContent, InfoMessage, Spinner } from "@serenity-tools/ui";
 import { useMachine } from "@xstate/react";
 import { useActiveDocumentInfoStore } from "../../../utils/document/activeDocumentInfoStore";
@@ -147,6 +148,14 @@ const PageRemountWrapper = (props: WorkspaceDrawerScreenProps<"Page">) => {
     }
   }, [pageId, workspaceId, props.navigation, state]);
 
+  const signatureKeyPair: KeyPair = useMemo(() => {
+    return {
+      publicKey: sodium.from_base64(activeDevice.signingPublicKey),
+      privateKey: sodium.from_base64(activeDevice.signingPrivateKey!),
+      keyType: "ed25519",
+    };
+  }, [activeDevice]);
+
   if (state.matches("hasNoAccess")) {
     return (
       <CenterContent>
@@ -162,6 +171,7 @@ const PageRemountWrapper = (props: WorkspaceDrawerScreenProps<"Page">) => {
         // to force unmount and mount the page
         key={pageId}
         updateTitle={updateTitle}
+        signatureKeyPair={signatureKeyPair}
       />
     );
   } else {

--- a/apps/backend/test/e2e/document/editing.e2e.ts
+++ b/apps/backend/test/e2e/document/editing.e2e.ts
@@ -62,6 +62,7 @@ test.describe("Edit document", () => {
       password: user1.password,
       stayLoggedIn: true,
     });
+    await delayForSeconds(2); // wait a bit until the editor loads
     const editorAfterLogin = page.locator("div[class='ProseMirror']");
     const afterLoginContent = await editorAfterLogin.innerHTML();
     expect(afterLoginContent).toBe(endingContent);


### PR DESCRIPTION
- move updateDocumentFolderPath from Page to PageScreen (for cleaner Page)
- use activeDevice for the signatureKeyPair used in snapshots and updates
- show actual email for real-time cursor data

Example:
<img width="423" alt="Screenshot 2022-10-20 at 08 33 11" src="https://user-images.githubusercontent.com/223045/196887501-311afa79-5b86-4936-85dc-d58600c8d89e.png">

