### PR TITLE
fix maxWidth for modals

### DIFF
--- a/packages/ui/components/modal/Modal.tsx
+++ b/packages/ui/components/modal/Modal.tsx
@@ -62,7 +62,9 @@ export const Modal = React.forwardRef(
           style={[
             styles.box,
             {
-              maxWidth: dimensions.width - 16, // making sure it doesn't go off screen on mobile
+              // dimensions.width - 16: making sure it doesn't go off screen on mobile
+              // 448: previous maxWidth of the modal
+              maxWidth: Math.min(dimensions.width - 16, 448),
             },
           ]}
         >


### PR DESCRIPTION
Caused by https://github.com/SerenityNotes/Serenity/pull/449

Before:
<img width="985" alt="Screenshot 2022-10-20 at 09 31 33" src="https://user-images.githubusercontent.com/223045/196898422-cba417a8-d0a8-4378-a268-f8f1d2b0c215.png">

After:
<img width="990" alt="Screenshot 2022-10-20 at 09 31 48" src="https://user-images.githubusercontent.com/223045/196898436-9b89202e-3d14-40e0-b7e8-12283a6ac22b.png">
