### PR TITLE
show a spinner instead of an empty document when loading and switching pages

### DIFF
--- a/apps/app/components/createWorkspaceForm/CreateWorkspaceForm.tsx
+++ b/apps/app/components/createWorkspaceForm/CreateWorkspaceForm.tsx
@@ -201,7 +201,6 @@ export function CreateWorkspaceForm(props: CreateWorkspaceFormProps) {
         onSuccess={() => {
           setIsPasswordModalVisible(false);
           setTimeout(() => {
-            console.log(inputRef.current);
             if (inputRef.current) {
               inputRef.current.focus();
             }

--- a/apps/app/components/editor/Editor.web.tsx
+++ b/apps/app/components/editor/Editor.web.tsx
@@ -4,7 +4,13 @@ import {
   getEditorBottombarStateFromEditor,
   updateEditor,
 } from "@serenity-tools/editor";
-import { tw, useHasEditorSidebar, View } from "@serenity-tools/ui";
+import {
+  CenterContent,
+  Spinner,
+  tw,
+  useHasEditorSidebar,
+  View,
+} from "@serenity-tools/ui";
 import { Editor as TipTapEditor } from "@tiptap/core";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { View as RNView } from "react-native";
@@ -22,6 +28,7 @@ export default function Editor({
   yAwarenessRef,
   openDrawer,
   documentId,
+  documentLoaded,
   workspaceId,
   isNew,
   updateTitle,
@@ -84,6 +91,14 @@ export default function Editor({
       documentId,
     });
   }, [workspaceId, documentId]);
+
+  if (!documentLoaded) {
+    return (
+      <CenterContent>
+        <Spinner fadeIn />
+      </CenterContent>
+    );
+  }
 
   return (
     // overflow-hidden needed so hidden elements with borders don't trigger scrolling behaviour

--- a/apps/app/components/editor/types.ts
+++ b/apps/app/components/editor/types.ts
@@ -3,6 +3,7 @@ import * as Y from "yjs";
 
 export type EditorProps = {
   documentId: string;
+  documentLoaded: boolean;
   workspaceId: string;
   yDocRef: React.MutableRefObject<Y.Doc>;
   yAwarenessRef: React.MutableRefObject<Awareness>;

--- a/apps/app/components/page/Page.tsx
+++ b/apps/app/components/page/Page.tsx
@@ -22,7 +22,7 @@ import {
 } from "@naisho/core";
 import { recreateDocumentKey } from "@serenity-tools/common";
 import sodium, { KeyPair } from "@serenity-tools/libsodium";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import {
   applyAwarenessUpdate,
@@ -69,7 +69,7 @@ export default function Page({
   const shouldReconnectWebsocketConnectionRef = useRef(true);
   const createSnapshotRef = useRef<boolean>(false); // only used for the UI
   const latestServerVersionRef = useRef<number | null>(null);
-  const editorInitializedRef = useRef<boolean>(false);
+  const [documentLoaded, setDocumentLoaded] = useState(false);
   const websocketState = useWebsocketState();
 
   const updateActiveDocumentInfoStore = useActiveDocumentInfoStore(
@@ -244,10 +244,7 @@ export default function Page({
               await applySnapshot(data.snapshot, snapshotKey);
             }
             await applyUpdates(data.updates, snapshotKey);
-            if (editorInitializedRef.current === false) {
-              // TODO initiate editor
-              editorInitializedRef.current = true;
-            }
+            setDocumentLoaded(true);
 
             // check for pending snapshots or pending updates and run them
             const pendingChanges = getPending(docId);
@@ -513,6 +510,7 @@ export default function Page({
       openDrawer={navigation.openDrawer}
       updateTitle={updateTitle}
       isNew={isNew}
+      documentLoaded={documentLoaded}
     />
   );
 }


### PR DESCRIPTION
Before this change an empty document was rendered. Now we wait until the document finished loading

Demo video: https://www.dropbox.com/s/s4ebji94t7s5bca/2022-11-04-improve-editor-loading-experience.mov?dl=0