### PR TITLE
Fix AvatarGroup

### DIFF
--- a/packages/ui/components/avatarGroup/AvatarGroup.tsx
+++ b/packages/ui/components/avatarGroup/AvatarGroup.tsx
@@ -4,14 +4,13 @@ import { Avatar as NbAvatar } from "native-base";
 // explicit path needed as it is not reexported in native-base directly
 import { IAvatarGroupProps } from "native-base/lib/typescript/components/composites/Avatar/types.d";
 import { tw } from "../../tailwind";
-import { View } from "../view/View";
 
 export type AvatarGroupProps = IAvatarGroupProps & {};
 
 export const AvatarGroup = forwardRef((props: AvatarGroupProps, ref) => {
   const { max = 3 } = props;
   const styles = StyleSheet.create({
-    avatarGroup: tw`flex items-center`,
+    avatarGroup: tw`flex items-center pl-4`, // pl fixes overflow from nb negative margin on children
   });
 
   return (


### PR DESCRIPTION
Fix `AvatarGroup` placement with additional _padding_, as the children get a negative _margin_ which otherwise will place them out of their parent-container.