### PR TITLE
cleanup dev dashboard links

### DIFF
--- a/apps/app/components/sidebar/Sidebar.tsx
+++ b/apps/app/components/sidebar/Sidebar.tsx
@@ -158,10 +158,6 @@ export default function Sidebar(props: DrawerContentComponentProps) {
         >
           Settings
         </SidebarLink>
-
-        <SidebarLink to={{ screen: "DevDashboard" }} iconName="dashboard-line">
-          Dev Dashboard
-        </SidebarLink>
       </View>
 
       {isPermanentLeftSidebar ? <SidebarDivider /> : null}

--- a/apps/app/navigation/screens/notFoundScreen/NotFoundScreen.tsx
+++ b/apps/app/navigation/screens/notFoundScreen/NotFoundScreen.tsx
@@ -1,47 +1,17 @@
-import {
-  StyleSheet,
-  TouchableOpacity,
-  useWindowDimensions,
-} from "react-native";
+import { useWindowDimensions } from "react-native";
 
-import { Text, View } from "@serenity-tools/ui";
+import { CenterContent, Heading, Link, tw } from "@serenity-tools/ui";
 import { RootStackScreenProps } from "../../../types/navigationProps";
 
-export default function NotFoundScreen({
-  navigation,
-}: RootStackScreenProps<"NotFound">) {
+export default function NotFoundScreen({}: RootStackScreenProps<"NotFound">) {
   useWindowDimensions(); // needed to ensure tw-breakpoints are triggered when resizing
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>This screen doesn't exist.</Text>
-      <TouchableOpacity
-        onPress={() => navigation.replace("DevDashboard")}
-        style={styles.link}
-      >
-        <Text style={styles.linkText}>Go to dashboard!</Text>
-      </TouchableOpacity>
-    </View>
+    <CenterContent>
+      <Heading lvl={1} style={tw`mb-4`}>
+        This screen doesn't exist :{"("}
+      </Heading>
+      <Link to={{ screen: "Root" }}>Go to home</Link>
+    </CenterContent>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-    padding: 20,
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: "bold",
-  },
-  link: {
-    marginTop: 15,
-    paddingVertical: 15,
-  },
-  linkText: {
-    fontSize: 14,
-    color: "#2e78b7",
-  },
-});


### PR DESCRIPTION
The only visual link left to the dev-dashboard is on `/register`

The not found page:
<img width="1035" alt="Screenshot 2022-11-18 at 16 21 43" src="https://user-images.githubusercontent.com/223045/202739539-0e7bd11a-cc16-4388-95bd-5e6003532c60.png">


Sidebar without the dev dashbo
<img width="259" alt="Screenshot 2022-11-18 at 16 21 56" src="https://user-images.githubusercontent.com/223045/202739564-786a2071-3cc3-426d-977a-1aeacbdba1b2.png">
ard:
