### PR TITLE
Styling for table of contents

### DIFF
--- a/packages/editor/components/editorSidebar/EditorSidebar.tsx
+++ b/packages/editor/components/editorSidebar/EditorSidebar.tsx
@@ -38,20 +38,14 @@ export default function EditorSidebar({
   >("editing");
 
   return (
-    <View
-      style={tw`w-sidebar h-full border-l border-gray-200 bg-gray-100 pt-4`}
-    >
-      <TabList
-        accessibilityLabel="Editor sidebar Tabs"
-        style={tw`flex-row px-4`}
-      >
+    <View style={tw`w-sidebar h-full border-l border-gray-200 bg-gray-100`}>
+      <TabList accessibilityLabel="Editor sidebar Tabs">
         <Tab
           tabId="editing"
           isActive={activeTab === "editing"}
           onPress={() => {
             setActiveTab("editing");
           }}
-          style={tw`mr-4`}
         >
           Edit
         </Tab>
@@ -65,8 +59,6 @@ export default function EditorSidebar({
           Table of Contents
         </Tab>
       </TabList>
-
-      <SidebarDivider />
 
       {activeTab === "tableOfContents" ? (
         <TabPanel tabId="tableOfContents">

--- a/packages/editor/components/tableOfContents/TableOfContents.tsx
+++ b/packages/editor/components/tableOfContents/TableOfContents.tsx
@@ -1,6 +1,6 @@
-import { Text, tw, View } from "@serenity-tools/ui";
-import { Editor } from "@tiptap/react";
 import React from "react";
+import { TableOfContentButton } from "@serenity-tools/ui";
+import { Editor } from "@tiptap/react";
 
 type Props = {
   editor: Editor | null;
@@ -10,26 +10,22 @@ export default function TableOfContents({ editor }: Props) {
   const content = editor?.getJSON().content || [];
 
   return (
-    <View style={tw`pl-2`}>
+    <>
       {content.map((entry, index) => {
         if (entry.type !== "heading") {
           return null;
         }
         return (
-          <Text
-            key={index}
-            variant="sm"
-            style={tw`pl-${entry.attrs?.level * 2 || 0}`}
-          >
+          <TableOfContentButton lvl={entry.attrs?.level}>
             {entry.content?.map((subEntry, index) => {
               if (subEntry.type !== "text") {
                 return null;
               }
               return <>{subEntry.text}</>;
             })}
-          </Text>
+          </TableOfContentButton>
         );
       })}
-    </View>
+    </>
   );
 }

--- a/packages/ui/components/tab/Tab.tsx
+++ b/packages/ui/components/tab/Tab.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { tw } from "../../tailwind";
 import { Pressable, PressableProps } from "../pressable/Pressable";
 import { Text } from "../text/Text";
+import { Platform } from "react-native";
+import { useFocusRing } from "@react-native-aria/focus";
 
 export type TabProps = PressableProps & { tabId: string; isActive: boolean };
 
@@ -11,14 +13,26 @@ export type TabProps = PressableProps & { tabId: string; isActive: boolean };
 // The current version seemed like an ok compromise for now.
 // Learn more https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role
 export function Tab({ isActive, tabId, children, ...otherProps }: TabProps) {
+  const { isFocusVisible, focusProps: focusRingProps } = useFocusRing();
+
+  const pressableStyles = [
+    tw`py-1.5 px-2`,
+    isFocusVisible && (Platform.OS === "web" ? tw`se-inset-focus-mini` : tw``),
+  ];
+
   return (
     <Pressable
+      {...focusRingProps} // sets onFocus and onBlur
       accessibilityRole="tab"
-      // @ts-expect-error exists in the docs, but not in the types https://necolas.github.io/react-native-web/docs/accessibility/
+      // exists in the docs, but not in the types https://necolas.github.io/react-native-web/docs/accessibility/
       accessibilityControls={`${tabId}-panel`}
       accessibilitySelected={isActive}
       nativeID={`${tabId}-tab`}
-      style={[tw`mx-2`]}
+      style={pressableStyles}
+      _focusVisible={{
+        // @ts-expect-error - web only
+        _web: { style: [pressableStyles, { outlineStyle: "none" }] },
+      }}
       {...otherProps}
     >
       <Text variant="xs" bold={isActive}>

--- a/packages/ui/components/tab/Tab.tsx
+++ b/packages/ui/components/tab/Tab.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { tw } from "../../tailwind";
 import { Pressable, PressableProps } from "../pressable/Pressable";
 import { Text } from "../text/Text";
 
@@ -17,6 +18,7 @@ export function Tab({ isActive, tabId, children, ...otherProps }: TabProps) {
       accessibilityControls={`${tabId}-panel`}
       accessibilitySelected={isActive}
       nativeID={`${tabId}-tab`}
+      style={[tw`mx-2`]}
       {...otherProps}
     >
       <Text variant="xs" bold={isActive}>

--- a/packages/ui/components/tabList/TabList.tsx
+++ b/packages/ui/components/tabList/TabList.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { tw } from "../../tailwind";
 import { View, ViewProps } from "../view/View";
 
 export type TabListProps = ViewProps & {
@@ -6,5 +7,11 @@ export type TabListProps = ViewProps & {
 };
 
 export function TabList(props: TabListProps) {
-  return <View accessibilityRole="tablist" {...props} />;
+  return (
+    <View
+      {...props}
+      accessibilityRole="tablist"
+      style={[tw`flex-row -mx-2 p-4 border-b border-gray-200`, props.style]}
+    />
+  );
 }

--- a/packages/ui/components/tabList/TabList.tsx
+++ b/packages/ui/components/tabList/TabList.tsx
@@ -11,7 +11,10 @@ export function TabList(props: TabListProps) {
     <View
       {...props}
       accessibilityRole="tablist"
-      style={[tw`flex-row -mx-2 p-4 border-b border-gray-200`, props.style]}
+      style={[
+        tw`flex-row -mx-2 py-2.5 px-4 border-b border-gray-200`,
+        props.style,
+      ]}
     />
   );
 }

--- a/packages/ui/components/tabPanel/TabPanel.tsx
+++ b/packages/ui/components/tabPanel/TabPanel.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { tw } from "../../tailwind";
 import { View, ViewProps } from "../view/View";
 
 export type TabPanelProps = ViewProps & {
@@ -12,6 +13,7 @@ export function TabPanel(props: TabPanelProps) {
       accessibilityRole="tabpanel"
       accessibilityLabelledBy={`${props.tabId}-tab`}
       nativeID={`${props.tabId}-panel`}
+      style={tw`py-4`}
       {...props}
     />
   );

--- a/packages/ui/components/tableOfContentButton/TableOfContentButton.tsx
+++ b/packages/ui/components/tableOfContentButton/TableOfContentButton.tsx
@@ -16,11 +16,13 @@ export const TableOfContentButton = React.forwardRef(
     const styles = StyleSheet.create({
       text: active ? tw`text-primary-500` : tw``,
       hover: active ? tw`bg-primary-100` : tw`bg-gray-200`,
+      active: tw`pr-3 border-r-3 border-primary-500/85`,
       focusVisible: Platform.OS === "web" ? tw`se-inset-focus-mini` : tw``,
     });
 
     const pressableStyles = [
       tw`py-1 px-4`,
+      active && styles.active,
       isHovered && styles.hover,
       isFocusVisible && styles.focusVisible,
     ];

--- a/packages/ui/components/tableOfContentButton/TableOfContentButton.tsx
+++ b/packages/ui/components/tableOfContentButton/TableOfContentButton.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+import { StyleSheet, Platform } from "react-native";
+import { useFocusRing } from "@react-native-aria/focus";
+import { Pressable, PressableProps, tw, Text } from "@serenity-tools/ui";
+
+export type TableOfContentButtonProps = PressableProps & {
+  active?: boolean;
+  lvl: number;
+};
+
+export const TableOfContentButton = React.forwardRef(
+  ({ active, lvl, ...rest }: TableOfContentButtonProps, ref: any) => {
+    const [isHovered, setIsHovered] = useState(false);
+    const { isFocusVisible, focusProps: focusRingProps } = useFocusRing();
+
+    const styles = StyleSheet.create({
+      text: active ? tw`text-primary-500` : tw``,
+      hover: active ? tw`bg-primary-100` : tw`bg-gray-200`,
+      focusVisible: Platform.OS === "web" ? tw`se-inset-focus-mini` : tw``,
+    });
+
+    const pressableStyles = [
+      tw`py-1 px-4`,
+      isHovered && styles.hover,
+      isFocusVisible && styles.focusVisible,
+    ];
+
+    return (
+      <Pressable
+        {...rest}
+        {...focusRingProps} // sets onFocus and onBlur
+        style={pressableStyles}
+        _focusVisible={{
+          // @ts-expect-error - web only
+          _web: { style: [pressableStyles, { outlineStyle: "none" }] },
+        }}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <Text
+          variant="xs"
+          style={[tw`pl-${(lvl - 1) * 3 || 0}`, styles.text]}
+          bold={lvl === 1}
+        >
+          {rest.children}
+        </Text>
+      </Pressable>
+    );
+  }
+);

--- a/packages/ui/components/tableOfContentButton/TableOfContentButton.tsx
+++ b/packages/ui/components/tableOfContentButton/TableOfContentButton.tsx
@@ -21,7 +21,7 @@ export const TableOfContentButton = React.forwardRef(
     });
 
     const pressableStyles = [
-      tw`py-1 px-4`,
+      tw`py-1.5 px-4`,
       active && styles.active,
       isHovered && styles.hover,
       isFocusVisible && styles.focusVisible,
@@ -41,7 +41,7 @@ export const TableOfContentButton = React.forwardRef(
       >
         <Text
           variant="xs"
-          style={[tw`pl-${(lvl - 1) * 3 || 0}`, styles.text]}
+          style={[tw`pl-${(lvl - 1) * 4 || 0}`, styles.text]}
           bold={lvl === 1}
         >
           {rest.children}

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -51,6 +51,7 @@ export * from "./components/spinner/Spinner";
 export * from "./components/tab/Tab";
 export * from "./components/tabList/TabList";
 export * from "./components/tabPanel/TabPanel";
+export * from "./components/tableOfContentButton/TableOfContentButton";
 export * from "./components/text/Text";
 export * from "./components/textArea/TextArea";
 export * from "./components/tooltip/Tooltip";


### PR DESCRIPTION
Add styling and usability elements to the _Table of Contents_ as preparation for its oncoming features.

- extract `TableOfConentButton` into its own component
- add styling _(focus, hover, overall)_
- move stylings to `Tab` components into themselves 