### PR TITLE
Improve responsive behaviour of the navigation sidebar

### DIFF
--- a/apps/app/components/accountMenu/AccountMenu.tsx
+++ b/apps/app/components/accountMenu/AccountMenu.tsx
@@ -41,7 +41,6 @@ export default function AccountMenu({
   const [isOpenAccountMenu, setIsOpenAccountMenu] = useState(false);
   const { isFocusVisible, focusProps: focusRingProps } = useFocusRing();
   const isDesktopDevice = useIsDesktopDevice();
-  const isPermanentLeftSidebar = useIsPermanentLeftSidebar();
   const navigation = useNavigation();
   const { activeDevice } = useAppContext();
   const [meResult] = useMeQuery();
@@ -80,16 +79,16 @@ export default function AccountMenu({
           testID={`${testIdPrefix}account-menu--trigger`}
         >
           <HStack
-            space={isPermanentLeftSidebar ? 2 : 3}
+            space={isDesktopDevice ? 2 : 3}
             alignItems="center"
             style={[
               tw`py-0.5 md:py-1.5 pr-2`,
               isFocusVisible && tw`se-inset-focus-mini`,
             ]}
           >
-            <WorkspaceAvatar size={isPermanentLeftSidebar ? "xs" : "sm"} />
+            <WorkspaceAvatar size={isDesktopDevice ? "xs" : "sm"} />
             <Text
-              variant={isPermanentLeftSidebar ? "xs" : "md"}
+              variant={isDesktopDevice ? "xs" : "md"}
               bold
               style={tw`-mr-1 max-w-30 text-gray-900`} // -mr needed for icon spacing, max-w needed for ellipsis
               numberOfLines={1}

--- a/apps/app/components/sidebar/Sidebar.tsx
+++ b/apps/app/components/sidebar/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Text,
   Tooltip,
   tw,
+  useIsDesktopDevice,
   useIsPermanentLeftSidebar,
   View,
 } from "@serenity-tools/ui";
@@ -36,6 +37,7 @@ export default function Sidebar(props: DrawerContentComponentProps) {
   const { workspaceId } = useWorkspace();
   const [isCreatingNewFolder, setIsCreatingNewFolder] = useState(false);
   const isPermanentLeftSidebar = useIsPermanentLeftSidebar();
+  const isDesktopDevice = useIsDesktopDevice();
 
   const [meWithWorkspaceLoadingInfo] = useMeWithWorkspaceLoadingInfoQuery({
     variables: {
@@ -119,11 +121,19 @@ export default function Sidebar(props: DrawerContentComponentProps) {
 
   return (
     // TODO override for now until we find out where the pt-1 comes from
-    <DrawerContentScrollView {...props} style={tw`bg-gray-100 -mt-1 pb-4`}>
+    <DrawerContentScrollView
+      {...props}
+      style={[
+        tw`bg-gray-100 -mt-1 pb-4`,
+        isDesktopDevice &&
+          !isPermanentLeftSidebar &&
+          tw`border-r border-gray-200`,
+      ]}
+    >
       <HStack
         alignItems="center"
         justifyContent="space-between"
-        style={tw`py-1.5 px-5 md:px-4`}
+        style={[tw`py-1.5 px-5 md:px-4`]}
       >
         <AccountMenu
           workspaceId={workspaceId}
@@ -136,14 +146,14 @@ export default function Sidebar(props: DrawerContentComponentProps) {
               props.navigation.closeDrawer();
             }}
             name="double-arrow-left"
-            size={"lg"}
+            size={isDesktopDevice ? "md" : "lg"}
           ></IconButton>
         )}
       </HStack>
 
-      {!isPermanentLeftSidebar ? <SidebarDivider collapsed /> : null}
+      {!isDesktopDevice ? <SidebarDivider collapsed /> : null}
 
-      <View style={!isPermanentLeftSidebar && tw`pt-5 pb-7`}>
+      <View style={isDesktopDevice ? tw`pt-4` : tw`pt-5 pb-7`}>
         <SidebarLink
           to={{
             screen: "Workspace",
@@ -160,7 +170,7 @@ export default function Sidebar(props: DrawerContentComponentProps) {
         </SidebarLink>
       </View>
 
-      {isPermanentLeftSidebar ? <SidebarDivider /> : null}
+      {isDesktopDevice ? <SidebarDivider /> : null}
 
       {isAuthorizedForThisWorkspace ? (
         <>
@@ -177,9 +187,9 @@ export default function Sidebar(props: DrawerContentComponentProps) {
                   setIsCreatingNewFolder(true);
                 }}
                 name="plus"
-                size={isPermanentLeftSidebar ? "md" : "lg"}
+                size={isDesktopDevice ? "md" : "lg"}
                 testID="root-create-folder"
-                color={isPermanentLeftSidebar ? "gray-400" : "gray-600"}
+                color={isDesktopDevice ? "gray-400" : "gray-600"}
               ></IconButton>
             </Tooltip>
           </HStack>

--- a/apps/app/navigation/Navigation.tsx
+++ b/apps/app/navigation/Navigation.tsx
@@ -10,6 +10,7 @@ import {
   Heading,
   Text,
   tw,
+  useIsDesktopDevice,
   useIsPermanentLeftSidebar,
 } from "@serenity-tools/ui";
 import * as Linking from "expo-linking";
@@ -74,6 +75,8 @@ const isPhoneDimensions = (width: number) => width < 768;
 
 function WorkspaceDrawerNavigator(props) {
   const isPermanentLeftSidebar = useIsPermanentLeftSidebar();
+  const isDesktopDevice = useIsDesktopDevice();
+
   const { width } = useWindowDimensions();
 
   return (
@@ -86,10 +89,13 @@ function WorkspaceDrawerNavigator(props) {
         headerStyle: [styles.header],
         drawerType: isPermanentLeftSidebar ? "permanent" : "front",
         drawerStyle: {
-          width: isPermanentLeftSidebar ? 240 : width,
+          width: isDesktopDevice ? 240 : width,
         },
         headerLeft: () => <PageHeaderLeft navigation={props.navigation} />,
-        overlayColor: "transparent",
+        overlayColor:
+          !isPermanentLeftSidebar && isDesktopDevice
+            ? tw.color("backdrop")
+            : "transparent",
       }}
     >
       <Drawer.Screen name="Page" component={PageScreen} />

--- a/packages/ui/hooks/useHasEditorSidebar/useHasEditorSidebar.ts
+++ b/packages/ui/hooks/useHasEditorSidebar/useHasEditorSidebar.ts
@@ -1,6 +1,6 @@
 import { useWindowDimensions } from "react-native";
 
-export const editorSidebarBreakPoint = 600;
+export const editorSidebarBreakPoint = 768; // md
 
 export function useHasEditorSidebar() {
   const { width } = useWindowDimensions();

--- a/packages/ui/hooks/useIsPermanentLeftSidebar/useIsPermanentLeftSidebar.ts
+++ b/packages/ui/hooks/useIsPermanentLeftSidebar/useIsPermanentLeftSidebar.ts
@@ -1,6 +1,6 @@
 import { useWindowDimensions } from "react-native";
 
-export const sidebarBreakPoint = 1000;
+export const sidebarBreakPoint = 1024; // lg
 
 export function useIsPermanentLeftSidebar() {
   const { width } = useWindowDimensions();


### PR DESCRIPTION
Add sensible breakpoints for when to show the navigation-`Sidebar` and `EditorSidebar` and adjust contained elements.

- adjust breakpoints to match design-system
- adjust `Sidebar` width to have an overlay feel between _desktop_ and _mobile_
- add _backdrop_