### PR TITLE
Improve IconButtons for navigational elements on mobile

### DIFF
--- a/apps/app/components/pageHeaderLeft/PageHeaderLeft.tsx
+++ b/apps/app/components/pageHeaderLeft/PageHeaderLeft.tsx
@@ -42,7 +42,7 @@ export function PageHeaderLeft(props: any) {
           {isInEditingMode ? (
             <HStack>
               <IconButton
-                size={"lg"}
+                size={"xl"}
                 name="arrow-go-back-line"
                 color={"gray-900"}
                 disabled={!canUndo}
@@ -53,7 +53,7 @@ export function PageHeaderLeft(props: any) {
                 dataSet={{ editorButton: "true" }}
               ></IconButton>
               <IconButton
-                size={"lg"}
+                size={"xl"}
                 name="arrow-go-forward-line"
                 color={"gray-900"}
                 disabled={!canRedo}
@@ -71,7 +71,7 @@ export function PageHeaderLeft(props: any) {
               }}
               name="arrow-left-line"
               color={"gray-900"}
-              size={isDesktopDevice ? "md" : "lg"}
+              size={isDesktopDevice ? "md" : "xl"}
               style={isDesktopDevice ? tw`` : tw`-mr-3`}
             />
           )}

--- a/apps/app/components/pageHeaderRight/PageHeaderRight.tsx
+++ b/apps/app/components/pageHeaderRight/PageHeaderRight.tsx
@@ -29,6 +29,7 @@ export function PageHeaderRight() {
         } px-3 border-b border-gray-200`}
         justifyContent="space-between"
         alignItems="center"
+        space={hasEditorSidebar ? 0 : 4}
       >
         {isInEditingMode && !hasEditorSidebar ? (
           <IconButton

--- a/apps/app/components/pageHeaderRight/PageHeaderRight.tsx
+++ b/apps/app/components/pageHeaderRight/PageHeaderRight.tsx
@@ -34,7 +34,7 @@ export function PageHeaderRight() {
         {isInEditingMode && !hasEditorSidebar ? (
           <IconButton
             name="check-line"
-            size="lg"
+            size="xl"
             color="primary-500"
             onPress={() => {
               triggerBlur();
@@ -74,7 +74,7 @@ export function PageHeaderRight() {
               <>
                 <IconButton
                   name="share-line"
-                  size="lg"
+                  size="xl"
                   color="gray-900"
                   onPress={() => {
                     setIsActiveShareModal(true);

--- a/apps/app/components/pageHeaderRight/PageHeaderRight.tsx
+++ b/apps/app/components/pageHeaderRight/PageHeaderRight.tsx
@@ -39,7 +39,7 @@ export function PageHeaderRight() {
             onPress={() => {
               triggerBlur();
             }}
-            // TODO transparent
+            transparent
           />
         ) : (
           <>

--- a/apps/app/components/sidebar/Sidebar.tsx
+++ b/apps/app/components/sidebar/Sidebar.tsx
@@ -149,7 +149,7 @@ export default function Sidebar(props: DrawerContentComponentProps) {
               props.navigation.closeDrawer();
             }}
             name="double-arrow-left"
-            size={isDesktopDevice ? "md" : "lg"}
+            size={isDesktopDevice ? "md" : "xl"}
           ></IconButton>
         )}
       </HStack>

--- a/apps/app/components/sidebar/Sidebar.tsx
+++ b/apps/app/components/sidebar/Sidebar.tsx
@@ -133,7 +133,10 @@ export default function Sidebar(props: DrawerContentComponentProps) {
       <HStack
         alignItems="center"
         justifyContent="space-between"
-        style={[tw`py-1.5 px-5 md:px-4`]}
+        style={[
+          tw`h-12 pr-2.5 pl-5 md:px-4`,
+          !isDesktopDevice && tw`border-b border-gray-200`,
+        ]}
       >
         <AccountMenu
           workspaceId={workspaceId}
@@ -150,8 +153,6 @@ export default function Sidebar(props: DrawerContentComponentProps) {
           ></IconButton>
         )}
       </HStack>
-
-      {!isDesktopDevice ? <SidebarDivider collapsed /> : null}
 
       <View style={isDesktopDevice ? tw`pt-4` : tw`pt-5 pb-7`}>
         <SidebarLink

--- a/apps/app/navigation/screens/designSystemScreen/DesignSystemScreen.tsx
+++ b/apps/app/navigation/screens/designSystemScreen/DesignSystemScreen.tsx
@@ -114,7 +114,10 @@ export default function DesignSystemScreen(
     return (
       <View
         {...props}
-        style={tw`-my-1.5 -mx-2 py-1.5 px-2 border border-dashed border-gray-200`}
+        style={[
+          tw`border border-dashed border-gray-200`,
+          props.padded && tw`-my-1.5 -mx-2 py-1.5 px-2`,
+        ]}
       >
         {props.children}
       </View>
@@ -406,15 +409,32 @@ export default function DesignSystemScreen(
           which for now only affects the clickable/hovered area.
         </Text>
         <Text variant="sm">
-          The default is regular, to make it a bit bigger use the{" "}
+          The default is medium, to make it a bit bigger use the{" "}
           <DSMono variant="property">lg</DSMono> property.
+        </Text>
+        <Text variant="sm" style={tw`mt-4`}>
+          For special cases such as the navigation-bar, which one should be able
+          to use with one hand, we use the{" "}
+          <DSMono variant="property">xl</DSMono> version for mobile to increase
+          clickability.
         </Text>
         <DSExampleArea>
           <IconButton name="double-arrow-left" color="gray-800" />
           <IconButton name="double-arrow-right" color="gray-800" />
           <IconButton name="double-arrow-left" color="gray-800" size="lg" />
           <IconButton name="double-arrow-right" color="gray-800" size="lg" />
+          <DSMarker>
+            <IconButton name="double-arrow-left" color="gray-800" size="xl" />
+          </DSMarker>
+          <DSMarker>
+            <IconButton name="double-arrow-right" color="gray-800" size="xl" />
+          </DSMarker>
         </DSExampleArea>
+        <Text style={tw`mt-4`} variant="xxs" muted>
+          Note that the xl-version has the same hover-area as the large one, as
+          it might be visible when the user clicks it, but the clickable area is
+          larger &#40;indicated by the dashed line&#41;.
+        </Text>
         <Heading lvl={3}>Styling</Heading>
         <Text variant="sm">
           As with <DSMono variant="component">Icons</DSMono> you can use the{" "}
@@ -669,7 +689,7 @@ export default function DesignSystemScreen(
               <UIHeading lvl={1} padded center>
                 Create your Account
               </UIHeading>
-              <DSMarker>
+              <DSMarker padded>
                 <Description variant={"login"}>
                   Type in your email and choose a password.
                   {"\n"}
@@ -722,7 +742,7 @@ export default function DesignSystemScreen(
         >
           <Box>
             <ModalHeader>Delete workspace ?</ModalHeader>
-            <DSMarker>
+            <DSMarker padded>
               <Description variant="modal">
                 Are you sure you want to delete the workspace “Paula's
                 Workspace” with all its pages and folders? You can't undo this
@@ -779,7 +799,7 @@ export default function DesignSystemScreen(
                     <UIHeading lvl={3} padded>
                       Manage Devices
                     </UIHeading>
-                    <DSMarker>
+                    <DSMarker padded>
                       <Description variant={"form"}>
                         The following list shows all the devices which are
                         currently linked to your account.

--- a/packages/ui/components/iconButton/IconButton.tsx
+++ b/packages/ui/components/iconButton/IconButton.tsx
@@ -68,7 +68,8 @@ export const IconButton = forwardRef((props: IconButtonProps, ref) => {
       // disable default outline styles
       // @ts-expect-error - web only
       _focusVisible={{ _web: { style: { outlineStyle: "none" } } }}
-      style={(styles.pressable, props.style)}
+      // @ts-expect-error - native base style mismatch
+      style={[styles.pressable, rest.style]}
     >
       {({ isPressed, isHovered, isFocused }) => {
         return (

--- a/packages/ui/components/iconButton/IconButton.tsx
+++ b/packages/ui/components/iconButton/IconButton.tsx
@@ -13,7 +13,7 @@ export type IconButtonProps = PressableProps & {
   name: IconNames;
   color?: Color;
   label?: string;
-  size?: "md" | "lg";
+  size?: "md" | "lg" | "xl";
   transparent?: boolean;
   isLoading?: boolean;
 };
@@ -30,7 +30,15 @@ export const IconButton = forwardRef((props: IconButtonProps, ref) => {
     ...rest
   } = props;
 
-  let dimensions = size === "lg" ? "w-8 h-8" : "w-5 h-5";
+  // the pressable style sizing defines the clickable area
+  const pressableSize = {
+    md: "h-5 w-5",
+    lg: "h-8 w-8",
+    xl: "h-12 w-12",
+  };
+
+  // the dimensions of the button define the visible area when clicked or hovered
+  let dimensions = size === "md" ? "w-5 h-5" : "w-8 h-8";
   let iconColor = color ?? "gray-400";
 
   if (label) {
@@ -42,9 +50,17 @@ export const IconButton = forwardRef((props: IconButtonProps, ref) => {
     iconColor = "gray-500";
   }
 
+  // --- dev only
+  // const showClickableArea = false;
+
   const styles = StyleSheet.create({
-    pressable: tw.style(dimensions), // defines clickable area
-    view: tw.style(
+    pressable: tw.style(
+      label
+        ? dimensions
+        : tw`flex justify-center items-center ${pressableSize[size]}`
+      // showClickableArea && tw`bg-collaboration-honey/40`
+    ),
+    stack: tw.style(
       `${dimensions} flex ${
         !label ? "justify-center" : ""
       } items-center bg-transparent rounded-md ${
@@ -75,7 +91,7 @@ export const IconButton = forwardRef((props: IconButtonProps, ref) => {
         return (
           <HStack
             style={[
-              styles.view,
+              styles.stack,
               isHovered && !isLoading && styles.hover,
               isPressed && !isLoading && styles.pressed,
               isFocusVisible && styles.focusVisible,


### PR DESCRIPTION
Improve the size of the `IconButton`s inside of `PageHeader`s and the `Sidebar`.

- add `xl` option to `IconButton` component
- update documentation
- improve spacing in `PageHeader`s 
- use xl-button in nav-elements
- mini fixes