### PR TITLE
Fix height issues for EditorSidebar

### DIFF
--- a/apps/app/components/editor/Editor.web.tsx
+++ b/apps/app/components/editor/Editor.web.tsx
@@ -129,70 +129,66 @@ export default function Editor({
 
   return (
     // overflow-hidden needed so hidden elements with borders don't trigger scrolling behaviour
-    <View style={tw`overflow-hidden`}>
-      <View>
-        <SerenityEditor
-          documentId={documentId}
-          yDocRef={yDocRef}
-          yAwarenessRef={yAwarenessRef}
-          isNew={wasNewOnFirstRender.current}
-          openDrawer={openDrawer}
-          updateTitle={updateTitle}
-          downloadAndDecryptFile={downloadAndDecryptFile}
-          onFocus={() => {
-            editorIsFocusedRef.current = true;
-            showAndPositionToolbar();
-            setIsInEditingMode(true);
-          }}
-          onBlur={(params) => {
-            if (
-              !(
-                params.event.relatedTarget &&
-                "nodeType" in params.event.relatedTarget &&
-                // check if click was not inside the editor bottom bar
-                (editorBottombarRef.current?.contains(
-                  params.event.relatedTarget
-                ) ||
-                  // check if click was not inside editor buttons e.g. undo/redo
-                  // @ts-expect-error
-                  params.event.relatedTarget.dataset.editorButton === "true")
-              )
-            ) {
-              editorIsFocusedRef.current = false;
-              if (editorBottombarWrapperRef.current) {
-                // @ts-expect-error - it's a div
-                editorBottombarWrapperRef.current.style.display = "none";
-              }
-              setIsInEditingMode(false);
+    <View style={tw`h-full overflow-hidden`}>
+      <SerenityEditor
+        documentId={documentId}
+        yDocRef={yDocRef}
+        yAwarenessRef={yAwarenessRef}
+        isNew={wasNewOnFirstRender.current}
+        openDrawer={openDrawer}
+        updateTitle={updateTitle}
+        downloadAndDecryptFile={downloadAndDecryptFile}
+        onFocus={() => {
+          editorIsFocusedRef.current = true;
+          showAndPositionToolbar();
+          setIsInEditingMode(true);
+        }}
+        onBlur={(params) => {
+          if (
+            !(
+              params.event.relatedTarget &&
+              "nodeType" in params.event.relatedTarget &&
+              // check if click was not inside the editor bottom bar
+              (editorBottombarRef.current?.contains(
+                params.event.relatedTarget
+              ) ||
+                // check if click was not inside editor buttons e.g. undo/redo
+                // @ts-expect-error
+                params.event.relatedTarget.dataset.editorButton === "true")
+            )
+          ) {
+            editorIsFocusedRef.current = false;
+            if (editorBottombarWrapperRef.current) {
+              // @ts-expect-error - it's a div
+              editorBottombarWrapperRef.current.style.display = "none";
             }
-          }}
-          onCreate={(params) => {
-            tipTapEditorRef.current = params.editor;
-          }}
-          onTransaction={(params) => {
-            const toolbarState = getEditorBottombarStateFromEditor(
-              params.editor
-            );
-            setEditorBottombarState(toolbarState);
-            editorToolbarService.send("updateToolbarState", { toolbarState });
-          }}
-          encryptAndUploadFile={encryptAndUploadFile}
-          shareOrSaveFile={({
-            mimeType,
-            contentAsBase64,
-            fileName: shareFileName,
-          }) => {
-            const dataUri = `data:${mimeType};base64,${contentAsBase64}`;
-            const element = document.createElement("a");
-            element.setAttribute("href", dataUri);
-            element.setAttribute("download", shareFileName);
-            element.style.display = "none";
-            document.body.appendChild(element);
-            element.click();
-            document.body.removeChild(element);
-          }}
-        />
-      </View>
+            setIsInEditingMode(false);
+          }
+        }}
+        onCreate={(params) => {
+          tipTapEditorRef.current = params.editor;
+        }}
+        onTransaction={(params) => {
+          const toolbarState = getEditorBottombarStateFromEditor(params.editor);
+          setEditorBottombarState(toolbarState);
+          editorToolbarService.send("updateToolbarState", { toolbarState });
+        }}
+        encryptAndUploadFile={encryptAndUploadFile}
+        shareOrSaveFile={({
+          mimeType,
+          contentAsBase64,
+          fileName: shareFileName,
+        }) => {
+          const dataUri = `data:${mimeType};base64,${contentAsBase64}`;
+          const element = document.createElement("a");
+          element.setAttribute("href", dataUri);
+          element.setAttribute("download", shareFileName);
+          element.style.display = "none";
+          document.body.appendChild(element);
+          element.click();
+          document.body.removeChild(element);
+        }}
+      />
       {!hasEditorSidebar && (
         <View
           ref={editorBottombarWrapperRef}

--- a/packages/editor/Editor.tsx
+++ b/packages/editor/Editor.tsx
@@ -173,7 +173,7 @@ export const Editor = (props: EditorProps) => {
   );
 
   return (
-    <div className="flex flex-auto flex-row">
+    <div className="flex h-full flex-auto flex-row">
       <View style={tw`flex-auto text-gray-900 dark:text-white`}>
         <div className="flex-auto overflow-y-auto overflow-x-hidden">
           <EditorContent

--- a/packages/editor/components/editorSidebar/EditorSidebar.tsx
+++ b/packages/editor/components/editorSidebar/EditorSidebar.tsx
@@ -12,6 +12,7 @@ import {
 import {
   EditorSidebarIcon,
   Heading,
+  ScrollView,
   SidebarButton,
   SidebarDivider,
   Tab,
@@ -43,7 +44,10 @@ export default function EditorSidebar({
   >("editing");
 
   return (
-    <View style={tw`w-sidebar h-full border-l border-gray-200 bg-gray-100`}>
+    // grow-0 overrides default of ScrollView to keep the assigned width
+    <ScrollView
+      style={tw`w-sidebar grow-0 border-l border-gray-200 bg-gray-100`}
+    >
       <TabList accessibilityLabel="Editor sidebar Tabs">
         <Tab
           tabId="editing"
@@ -389,6 +393,6 @@ export default function EditorSidebar({
           </SidebarButton>
         </TabPanel>
       )}
-    </View>
+    </ScrollView>
   );
 }

--- a/packages/editor/components/editorSidebar/EditorSidebar.tsx
+++ b/packages/editor/components/editorSidebar/EditorSidebar.tsx
@@ -336,61 +336,6 @@ export default function EditorSidebar({
           ) : null}
 
           <SidebarDivider />
-
-          <Heading lvl={4} style={tw`ml-4`} padded>
-            Formats
-          </Heading>
-
-          <SidebarButton
-            onPress={() => editor?.chain().focus().toggleBold().run()}
-          >
-            <EditorSidebarIcon
-              isActive={editor?.isActive("bold") || false}
-              name="bold"
-            />
-            <Text variant="xs" bold={editor?.isActive("bold") || false}>
-              Bold
-            </Text>
-          </SidebarButton>
-
-          <SidebarButton
-            onPress={() => editor?.chain().focus().toggleItalic().run()}
-          >
-            <EditorSidebarIcon
-              isActive={editor?.isActive("italic") || false}
-              name="italic"
-            />
-            <Text variant="xs" bold={editor?.isActive("italic") || false}>
-              Italic
-            </Text>
-          </SidebarButton>
-
-          <SidebarButton
-            onPress={() => editor?.chain().focus().toggleCode().run()}
-          >
-            <EditorSidebarIcon
-              isActive={editor?.isActive("code") || false}
-              name="code-view"
-            />
-            <Text variant="xs" bold={editor?.isActive("code") || false}>
-              Code
-            </Text>
-          </SidebarButton>
-
-          {/* styling dummy */}
-          <SidebarButton
-            onPress={() =>
-              editor?.chain().focus().toggleLink({ href: "#" }).run()
-            }
-          >
-            <EditorSidebarIcon
-              isActive={editor?.isActive("link") || false}
-              name="link"
-            />
-            <Text variant="xs" bold={editor?.isActive("link") || false}>
-              Link
-            </Text>
-          </SidebarButton>
         </TabPanel>
       )}
     </ScrollView>


### PR DESCRIPTION
Fix the limited sizing on Safari and the overall issue of wrong height calculation.
Make it scrollable.

- and remove _Formats_ actions from `EditorSidebar` as we already have them accessible in the `BubbleMenu`