### PR TITLE
Fix preview height for small images

### DIFF
--- a/packages/editor-file-extension/src/components/Image.tsx
+++ b/packages/editor-file-extension/src/components/Image.tsx
@@ -37,7 +37,7 @@ export const Image: React.FC<Props> = (props) => {
       {state.step !== "done" ? (
         <View
           style={[
-            tw``,
+            tw`w-[${width}px] max-w-full`,
             {
               aspectRatio: `1 / ${height / width}`,
             },


### PR DESCRIPTION
Add _width_ to Image preview to ensure right dimensions even when the image is smaller than the Editor content.