### PR TITLE
Quiet Links

### DIFF
--- a/apps/app/components/register/RegisterForm.tsx
+++ b/apps/app/components/register/RegisterForm.tsx
@@ -191,6 +191,8 @@ export default function RegisterForm(props: Props) {
           <LinkExternal
             variant="xs"
             href="https://www.serenity.re/en/notes/terms-of-service"
+            quiet
+            muted
           >
             terms of services
           </LinkExternal>{" "}
@@ -198,6 +200,8 @@ export default function RegisterForm(props: Props) {
           <LinkExternal
             variant="xs"
             href="https://www.serenity.re/en/notes/privacy-policy"
+            quiet
+            muted
           >
             privacy policy
           </LinkExternal>

--- a/apps/app/navigation/screens/designSystemScreen/DesignSystemScreen.tsx
+++ b/apps/app/navigation/screens/designSystemScreen/DesignSystemScreen.tsx
@@ -651,7 +651,7 @@ export default function DesignSystemScreen(
           >
             <Text variant="sm">
               I accept our{" "}
-              <Link to={{ screen: "EncryptDecryptImageTest" }}>
+              <Link to={{ screen: "EncryptDecryptImageTest" }} quiet>
                 Encrypt / Decrypt Image
               </Link>{" "}
               test
@@ -717,6 +717,8 @@ export default function DesignSystemScreen(
                 <LinkExternal
                   variant="xs"
                   href="https://www.serenity.re/en/notes/terms-of-service"
+                  quiet
+                  muted
                 >
                   terms of services
                 </LinkExternal>{" "}
@@ -724,6 +726,8 @@ export default function DesignSystemScreen(
                 <LinkExternal
                   variant="xs"
                   href="https://www.serenity.re/en/notes/privacy-policy"
+                  quiet
+                  muted
                 >
                   privacy policy
                 </LinkExternal>
@@ -1434,7 +1438,7 @@ export default function DesignSystemScreen(
           parent is set to <DSMono variant="property">bold</DSMono>.
         </Text>
         <Text variant="sm" style={tw`mt-2`}>
-          Notice though the color stays the same no matter if the parent{" "}
+          Be aware that the color stays the same no matter if the parent{" "}
           <DSMono variant="component">Text</DSMono> is set to be{" "}
           <DSMono variant="property">muted</DSMono> or the color is changed, to
           ensure a consistent and distinguishable look &amp; feel of all{" "}
@@ -1458,6 +1462,43 @@ export default function DesignSystemScreen(
             <Link to={{ screen: "EncryptDecryptImageTest" }}>
               Encrypt / Decrypt Image
             </Link>
+          </Text>
+        </DSExampleArea>
+        <Heading lvl={3}>Quiet</Heading>
+        <Text variant="sm">
+          If you want to add a <DSMono variant="component">Link</DSMono> but
+          need to match the text-colors to make it less pronounced, add the
+          <DSMono variant="property">quiet</DSMono> property to avoid the
+          primary-color override.
+        </Text>
+        <Text variant="sm" style={tw`mt-2`}>
+          Notice though you will need to set both the{" "}
+          <DSMono variant="property">variant</DSMono> and if need be the{" "}
+          <DSMono variant="property">muted</DSMono> properties to match the{" "}
+          <DSMono variant="component">Text</DSMono> surrounding the{" "}
+          <DSMono variant="component">Link</DSMono> .
+        </Text>
+        <DSExampleArea vertical>
+          <Text variant="xs" muted>
+            Yes, I do agree to Serenity's{" "}
+            <LinkExternal
+              variant="xs"
+              href="https://www.serenity.re/en/notes/terms-of-service"
+              quiet
+              muted
+            >
+              terms of services
+            </LinkExternal>{" "}
+            and{" "}
+            <LinkExternal
+              variant="xs"
+              href="https://www.serenity.re/en/notes/privacy-policy"
+              quiet
+              muted
+            >
+              privacy policy
+            </LinkExternal>
+            .
           </Text>
         </DSExampleArea>
         <Heading lvl={4} style={h4Styles}>

--- a/packages/ui/components/link/Link.tsx
+++ b/packages/ui/components/link/Link.tsx
@@ -21,15 +21,17 @@ declare type Props<ParamList extends ReactNavigation.RootParamList> = {
   ) => void;
 } & (TextProps & {
   children: React.ReactNode;
+  quiet?: boolean;
 });
 
 export const createLinkStyles = () => {
   return StyleSheet.create({
     // reset outline for web focusVisible
     default: tw.style(
-      `text-primary-500 underline`,
+      `underline`,
       Platform.OS === "web" && { outlineStyle: "none" }
     ),
+    primary: tw`text-primary-500`,
     focusVisible:
       Platform.OS === "web" ? tw`se-outline-focus-mini rounded` : {},
   });
@@ -47,6 +49,7 @@ export function Link<ParamList extends ReactNavigation.RootParamList>(
       {...focusRingProps} // sets onFocus and onBlur
       style={[
         styles.default,
+        !props.quiet && styles.primary,
         isFocusVisible && styles.focusVisible,
         props.style,
       ]}

--- a/packages/ui/components/linkButton/LinkButton.tsx
+++ b/packages/ui/components/linkButton/LinkButton.tsx
@@ -7,10 +7,11 @@ import { Text, TextVariants } from "../text/Text";
 export type LinkButtonProps = PressableProps & {
   children: React.ReactNode;
   variant?: TextVariants;
+  quiet?: boolean;
 };
 
 export function LinkButton(props: LinkButtonProps) {
-  const { variant = "xs" } = props;
+  const { variant = "xs", quiet } = props;
   const { isFocusVisible, focusProps: focusRingProps } = useFocusRing();
   const styles = createLinkStyles();
 
@@ -20,7 +21,10 @@ export function LinkButton(props: LinkButtonProps) {
       {...focusRingProps} // sets onFocus and onBlur
       style={(isFocusVisible && styles.focusVisible, props.style)}
     >
-      <Text variant={variant} style={styles.default}>
+      <Text
+        variant={variant}
+        style={[styles.default, !quiet && styles.primary]}
+      >
         {props.children}
       </Text>
     </Pressable>

--- a/packages/ui/components/linkExternal/LinkExternal.tsx
+++ b/packages/ui/components/linkExternal/LinkExternal.tsx
@@ -13,10 +13,11 @@ export type LinkExternalProps = TextProps & {
   children: React.ReactNode;
   href: string;
   icon?: boolean;
+  quiet?: boolean;
 };
 
 export function LinkExternal(props: LinkExternalProps) {
-  const { variant = "md", icon } = props;
+  const { variant = "md", icon, quiet } = props;
   const { isFocusVisible, focusProps: focusRingProps } = useFocusRing();
   const styles = createLinkStyles();
 
@@ -50,6 +51,7 @@ export function LinkExternal(props: LinkExternalProps) {
         variant={variant}
         style={[
           styles.default,
+          !quiet && styles.primary,
           isFocusVisible && styles.focusVisible,
           props.style,
         ]}
@@ -60,7 +62,7 @@ export function LinkExternal(props: LinkExternalProps) {
         <View style={tw`pl-0.5`}>
           <Icon
             name="external-link-line"
-            color={"primary-500"}
+            color={quiet ? "gray-700" : "primary-500"}
             size={iconSizes[variant]}
             mobileSize={iconSizes[variant]}
           />


### PR DESCRIPTION
Add a _quiet_ option for all Links (`Link` , `LinkExternal` , `LinkButton`) to make them less pronounced when needed.

- add _quiet_ property and adjust stylings
- update documentation
- use quiet links in `RegisterForm` 